### PR TITLE
feat: Allow resource exclusions from recommended alarms using IDs

### DIFF
--- a/API.md
+++ b/API.md
@@ -12163,6 +12163,7 @@ const lambdaRecommendedAlarmsConfig: LambdaRecommendedAlarmsConfig = { ... }
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsConfig.property.defaultInsufficientDataAction">defaultInsufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm has insufficient data. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsConfig.property.defaultOkAction">defaultOkAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm enters the ok state. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsConfig.property.excludeAlarms">excludeAlarms</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsMetrics">LambdaRecommendedAlarmsMetrics</a>[]</code> | Alarm metrics to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsConfig.property.excludeResources">excludeResources</a></code> | <code>string[]</code> | The resources to exclude from the recommended alarms. |
 
 ---
 
@@ -12266,6 +12267,20 @@ Alarm metrics to exclude from the recommended alarms.
 
 ---
 
+##### `excludeResources`<sup>Optional</sup> <a name="excludeResources" id="@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsConfig.property.excludeResources"></a>
+
+```typescript
+public readonly excludeResources: string[];
+```
+
+- *Type:* string[]
+
+The resources to exclude from the recommended alarms.
+
+Use a resources id to exclude a specific resource.
+
+---
+
 ### LambdaRecommendedAlarmsProps <a name="LambdaRecommendedAlarmsProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsProps"></a>
 
 #### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsProps.Initializer"></a>
@@ -12288,6 +12303,7 @@ const lambdaRecommendedAlarmsProps: LambdaRecommendedAlarmsProps = { ... }
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsProps.property.defaultInsufficientDataAction">defaultInsufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm has insufficient data. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsProps.property.defaultOkAction">defaultOkAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm enters the ok state. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsProps.property.excludeAlarms">excludeAlarms</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsMetrics">LambdaRecommendedAlarmsMetrics</a>[]</code> | Alarm metrics to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsProps.property.excludeResources">excludeResources</a></code> | <code>string[]</code> | The resources to exclude from the recommended alarms. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsProps.property.lambdaFunction">lambdaFunction</a></code> | <code>aws-cdk-lib.aws_lambda.IFunction</code> | The lambda function to apply the recommended alarms. |
 
 ---
@@ -12389,6 +12405,20 @@ public readonly excludeAlarms: LambdaRecommendedAlarmsMetrics[];
 - *Default:* None
 
 Alarm metrics to exclude from the recommended alarms.
+
+---
+
+##### `excludeResources`<sup>Optional</sup> <a name="excludeResources" id="@renovosolutions/cdk-library-cloudwatch-alarms.LambdaRecommendedAlarmsProps.property.excludeResources"></a>
+
+```typescript
+public readonly excludeResources: string[];
+```
+
+- *Type:* string[]
+
+The resources to exclude from the recommended alarms.
+
+Use a resources id to exclude a specific resource.
 
 ---
 
@@ -13463,6 +13493,7 @@ const s3RecommendedAlarmsConfig: S3RecommendedAlarmsConfig = { ... }
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsConfig.property.defaultInsufficientDataAction">defaultInsufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm has insufficient data. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsConfig.property.defaultOkAction">defaultOkAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm enters the ok state. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsConfig.property.excludeAlarms">excludeAlarms</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsMetrics">S3RecommendedAlarmsMetrics</a>[]</code> | Alarm metrics to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsConfig.property.excludeResources">excludeResources</a></code> | <code>string[]</code> | The resources to exclude from the recommended alarms. |
 
 ---
 
@@ -13542,6 +13573,20 @@ Alarm metrics to exclude from the recommended alarms.
 
 ---
 
+##### `excludeResources`<sup>Optional</sup> <a name="excludeResources" id="@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsConfig.property.excludeResources"></a>
+
+```typescript
+public readonly excludeResources: string[];
+```
+
+- *Type:* string[]
+
+The resources to exclude from the recommended alarms.
+
+Use a resources id to exclude a specific resource.
+
+---
+
 ### S3RecommendedAlarmsProps <a name="S3RecommendedAlarmsProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsProps"></a>
 
 #### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsProps.Initializer"></a>
@@ -13562,6 +13607,7 @@ const s3RecommendedAlarmsProps: S3RecommendedAlarmsProps = { ... }
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsProps.property.defaultInsufficientDataAction">defaultInsufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm has insufficient data. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsProps.property.defaultOkAction">defaultOkAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm enters the ok state. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsProps.property.excludeAlarms">excludeAlarms</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsMetrics">S3RecommendedAlarmsMetrics</a>[]</code> | Alarm metrics to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsProps.property.excludeResources">excludeResources</a></code> | <code>string[]</code> | The resources to exclude from the recommended alarms. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsProps.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | The S3 bucket to apply the recommended alarms to. |
 
 ---
@@ -13639,6 +13685,20 @@ public readonly excludeAlarms: S3RecommendedAlarmsMetrics[];
 - *Default:* None
 
 Alarm metrics to exclude from the recommended alarms.
+
+---
+
+##### `excludeResources`<sup>Optional</sup> <a name="excludeResources" id="@renovosolutions/cdk-library-cloudwatch-alarms.S3RecommendedAlarmsProps.property.excludeResources"></a>
+
+```typescript
+public readonly excludeResources: string[];
+```
+
+- *Type:* string[]
+
+The resources to exclude from the recommended alarms.
+
+Use a resources id to exclude a specific resource.
 
 ---
 
@@ -15959,6 +16019,7 @@ const snsRecommendedAlarmsConfig: SnsRecommendedAlarmsConfig = { ... }
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsConfig.property.defaultInsufficientDataAction">defaultInsufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm has insufficient data. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsConfig.property.defaultOkAction">defaultOkAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm enters the ok state. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsConfig.property.excludeAlarms">excludeAlarms</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsMetrics">SnsRecommendedAlarmsMetrics</a>[]</code> | Alarm metrics to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsConfig.property.excludeResources">excludeResources</a></code> | <code>string[]</code> | The resources to exclude from the recommended alarms. |
 
 ---
 
@@ -16098,6 +16159,20 @@ Alarm metrics to exclude from the recommended alarms.
 
 ---
 
+##### `excludeResources`<sup>Optional</sup> <a name="excludeResources" id="@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsConfig.property.excludeResources"></a>
+
+```typescript
+public readonly excludeResources: string[];
+```
+
+- *Type:* string[]
+
+The resources to exclude from the recommended alarms.
+
+Use a resources id to exclude a specific resource.
+
+---
+
 ### SnsRecommendedAlarmsProps <a name="SnsRecommendedAlarmsProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsProps"></a>
 
 #### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsProps.Initializer"></a>
@@ -16123,6 +16198,7 @@ const snsRecommendedAlarmsProps: SnsRecommendedAlarmsProps = { ... }
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsProps.property.defaultInsufficientDataAction">defaultInsufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm has insufficient data. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsProps.property.defaultOkAction">defaultOkAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm enters the ok state. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsProps.property.excludeAlarms">excludeAlarms</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsMetrics">SnsRecommendedAlarmsMetrics</a>[]</code> | Alarm metrics to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsProps.property.excludeResources">excludeResources</a></code> | <code>string[]</code> | The resources to exclude from the recommended alarms. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsProps.property.topic">topic</a></code> | <code>aws-cdk-lib.aws_sns.ITopic</code> | The SNS topic for which to create the alarms. |
 
 ---
@@ -16260,6 +16336,20 @@ public readonly excludeAlarms: SnsRecommendedAlarmsMetrics[];
 - *Default:* None
 
 Alarm metrics to exclude from the recommended alarms.
+
+---
+
+##### `excludeResources`<sup>Optional</sup> <a name="excludeResources" id="@renovosolutions/cdk-library-cloudwatch-alarms.SnsRecommendedAlarmsProps.property.excludeResources"></a>
+
+```typescript
+public readonly excludeResources: string[];
+```
+
+- *Type:* string[]
+
+The resources to exclude from the recommended alarms.
+
+Use a resources id to exclude a specific resource.
 
 ---
 
@@ -17642,6 +17732,7 @@ const sqsRecommendedAlarmsConfig: SqsRecommendedAlarmsConfig = { ... }
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsConfig.property.defaultInsufficientDataAction">defaultInsufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm has insufficient data. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsConfig.property.defaultOkAction">defaultOkAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm enters the ok state. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsConfig.property.excludeAlarms">excludeAlarms</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsMetrics">SqsRecommendedAlarmsMetrics</a>[]</code> | Alarm metrics to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsConfig.property.excludeResources">excludeResources</a></code> | <code>string[]</code> | The resources to exclude from the recommended alarms. |
 
 ---
 
@@ -17745,6 +17836,20 @@ Alarm metrics to exclude from the recommended alarms.
 
 ---
 
+##### `excludeResources`<sup>Optional</sup> <a name="excludeResources" id="@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsConfig.property.excludeResources"></a>
+
+```typescript
+public readonly excludeResources: string[];
+```
+
+- *Type:* string[]
+
+The resources to exclude from the recommended alarms.
+
+Use a resources id to exclude a specific resource.
+
+---
+
 ### SqsRecommendedAlarmsProps <a name="SqsRecommendedAlarmsProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsProps"></a>
 
 Properties for the SqsRecommendedAlarms construct.
@@ -17769,6 +17874,7 @@ const sqsRecommendedAlarmsProps: SqsRecommendedAlarmsProps = { ... }
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsProps.property.defaultInsufficientDataAction">defaultInsufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm has insufficient data. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsProps.property.defaultOkAction">defaultOkAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm enters the ok state. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsProps.property.excludeAlarms">excludeAlarms</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsMetrics">SqsRecommendedAlarmsMetrics</a>[]</code> | Alarm metrics to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsProps.property.excludeResources">excludeResources</a></code> | <code>string[]</code> | The resources to exclude from the recommended alarms. |
 | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsProps.property.queue">queue</a></code> | <code>aws-cdk-lib.aws_sqs.IQueue</code> | The SQS queue for which to create the alarms. |
 
 ---
@@ -17870,6 +17976,20 @@ public readonly excludeAlarms: SqsRecommendedAlarmsMetrics[];
 - *Default:* None
 
 Alarm metrics to exclude from the recommended alarms.
+
+---
+
+##### `excludeResources`<sup>Optional</sup> <a name="excludeResources" id="@renovosolutions/cdk-library-cloudwatch-alarms.SqsRecommendedAlarmsProps.property.excludeResources"></a>
+
+```typescript
+public readonly excludeResources: string[];
+```
+
+- *Type:* string[]
+
+The resources to exclude from the recommended alarms.
+
+Use a resources id to exclude a specific resource.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,54 @@ new lambda.Function(stack2, 'Lambda2', {
 });
 ```
 
+### Exclusions
+
+You can exclude specific alarms or specific resources. Alarms use the available metrics enums and resources use the string used for a resources id. For example below Lambda1 will not have alarms created and there will be no alarm for the Duration metric for either lambda function.
+
+```typescript
+import { App, Stack, Aspects, aws_lambda as lambda } from 'aws-cdk-lib';
+import * as recommendedalarms from '@renovosolutions/cdk-library-cloudwatch-alarms';
+
+const app = new App();
+const stack = new Stack(app, 'TestStack', {
+  env: {
+    account: '123456789012', // not a real account
+    region: 'us-east-1',
+  },
+});
+
+const appAspects = Aspects.of(app);
+
+appAspects.add(
+  new recommendedalarms.LambdaRecommendedAlarmsAspect({
+    excludeResources: ['Lambda1'],
+    excludeAlarms: [recommendedalarms.LambdaRecommendedAlarmsMetrics.DURATION]
+    exclude 
+    configDurationAlarm: {
+      threshold: 15,
+    },
+    configErrorsAlarm: {
+      threshold: 1,
+    },
+    configThrottlesAlarm: {
+      threshold: 0,
+    },
+  }),
+);
+
+new lambda.Function(stack, 'Lambda1', {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: 'index.handler',
+  code: lambda.Code.fromInline('exports.handler = async (event) => { console.log(event); }'),
+});
+
+new lambda.Function(stack, 'Lambda2', {
+  runtime: lambda.Runtime.NODEJS_20_X,
+  handler: 'index.handler',
+  code: lambda.Code.fromInline('exports.handler = async (event) => { console.log(event); }'),
+});
+```
+
 ## References
 
 - [AWS Recommended Alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html)

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -442,6 +442,12 @@ export interface LambdaRecommendedAlarmsConfig {
    */
   readonly excludeAlarms?: LambdaRecommendedAlarmsMetrics[];
   /**
+   * The resources to exclude from the recommended alarms.
+   *
+   * Use a resources id to exclude a specific resource.
+   */
+  readonly excludeResources?: string[];
+  /**
    * The configuration for the Errors alarm.
    */
   readonly configErrorsAlarm: LambdaErrorsAlarmConfig;
@@ -642,12 +648,16 @@ export class LambdaRecommendedAlarmsAspect implements IAspect {
 
   public visit(node: IConstruct): void {
     if (node instanceof lambda.Function) {
-      const lambdaFunction = node as lambda.IFunction;
+      if (this.props.excludeResources && this.props.excludeResources.includes(node.node.id)) {
+        return;
+      } else {
+        const lambdaFunction = node as lambda.IFunction;
 
-      new LambdaRecommendedAlarms(node, 'LambdaRecommendedAlarmsFromAspect', {
-        lambdaFunction,
-        ...this.props,
-      });
+        new LambdaRecommendedAlarms(node, 'LambdaRecommendedAlarmsFromAspect', {
+          lambdaFunction,
+          ...this.props,
+        });
+      }
     }
   }
 }

--- a/src/s3.ts
+++ b/src/s3.ts
@@ -243,6 +243,12 @@ export interface S3RecommendedAlarmsConfig {
    */
   readonly excludeAlarms?: S3RecommendedAlarmsMetrics[];
   /**
+   * The resources to exclude from the recommended alarms.
+   *
+   * Use a resources id to exclude a specific resource.
+   */
+  readonly excludeResources?: string[];
+  /**
    * The configuration for the 4xx errors alarm.
    */
   readonly config4xxErrorsAlarm?: S3Bucket4xxErrorsAlarmConfig;
@@ -369,12 +375,16 @@ export class S3RecommendedAlarmsAspect implements IAspect {
 
   public visit(node: IConstruct): void {
     if (node instanceof s3.Bucket) {
-      const bucket = node as s3.Bucket;
+      if (this.props?.excludeResources && this.props.excludeResources.includes(node.node.id)) {
+        return;
+      } else {
+        const bucket = node as s3.Bucket;
 
-      new S3RecommendedAlarms(bucket, 'S3RecommendedAlarmsFromAspect', {
-        bucket,
-        ...this.props,
-      });
+        new S3RecommendedAlarms(bucket, 'S3RecommendedAlarmsFromAspect', {
+          bucket,
+          ...this.props,
+        });
+      }
     }
   }
 }

--- a/src/sns.ts
+++ b/src/sns.ts
@@ -651,6 +651,12 @@ export interface SnsRecommendedAlarmsConfig {
    */
   readonly excludeAlarms?: SnsRecommendedAlarmsMetrics[];
   /**
+   * The resources to exclude from the recommended alarms.
+   *
+   * Use a resources id to exclude a specific resource.
+   */
+  readonly excludeResources?: string[];
+  /**
    * The configuration for the NumberOfMessagesPublished alarm.
    */
   readonly configNumberOfMessagesPublishedAlarm: SnsNumberOfMessagesPublishedAlarmConfig;
@@ -976,12 +982,16 @@ export class SnsRecommendedAlarmsAspect implements IAspect {
 
   public visit(node: IConstruct): void {
     if (node instanceof sns.Topic) {
-      const topic = node as sns.Topic;
+      if (this.props.excludeResources && this.props.excludeResources.includes(node.node.id)) {
+        return;
+      } else {
+        const topic = node as sns.Topic;
 
-      new SnsRecommendedAlarms(node, 'SnsRecommendedAlarmsFromAspect', {
-        topic,
-        ...this.props,
-      });
+        new SnsRecommendedAlarms(node, 'SnsRecommendedAlarmsFromAspect', {
+          topic,
+          ...this.props,
+        });
+      }
     }
   }
 }

--- a/src/sqs.ts
+++ b/src/sqs.ts
@@ -386,6 +386,12 @@ export interface SqsRecommendedAlarmsConfig {
    */
   readonly excludeAlarms?: SqsRecommendedAlarmsMetrics[];
   /**
+   * The resources to exclude from the recommended alarms.
+   *
+   * Use a resources id to exclude a specific resource.
+   */
+  readonly excludeResources?: string[];
+  /**
    * The configuration for the approximate age of oldest message alarm.
    */
   readonly configApproximateAgeOfOldestMessageAlarm: SqsApproximateAgeOfOldestMessageAlarmConfig;
@@ -585,12 +591,16 @@ export class SqsRecommendedAlarmsAspect implements IAspect {
 
   public visit(node: IConstruct): void {
     if (node instanceof sqs.Queue) {
-      const queue = node as sqs.Queue;
+      if (this.props.excludeResources && this.props.excludeResources.includes(node.node.id)) {
+        return;
+      } else {
+        const queue = node as sqs.Queue;
 
-      new SqsRecommendedAlarms(queue, 'SqsRecommendedAlarmsFromAspect', {
-        queue,
-        ...this.props,
-      });
+        new SqsRecommendedAlarms(queue, 'SqsRecommendedAlarmsFromAspect', {
+          queue,
+          ...this.props,
+        });
+      }
     }
   }
 };

--- a/test/__snapshots__/sqs.test.ts.snap
+++ b/test/__snapshots__/sqs.test.ts.snap
@@ -12,6 +12,17 @@ Object {
   "Resources": Object {
     "Queue4A7E3555": Object {
       "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "RedrivePolicy": Object {
+          "deadLetterTargetArn": Object {
+            "Fn::GetAtt": Array [
+              "dlq09C78ACC",
+              "Arn",
+            ],
+          },
+          "maxReceiveCount": 1,
+        },
+      },
       "Type": "AWS::SQS::Queue",
       "UpdateReplacePolicy": "Delete",
     },
@@ -157,6 +168,167 @@ Object {
             "Value": Object {
               "Fn::GetAtt": Array [
                 "Queue4A7E3555",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 15,
+        "MetricName": "NumberOfMessagesSent",
+        "Namespace": "AWS/SQS",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "dlq09C78ACC": Object {
+      "DeletionPolicy": "Delete",
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "dlqSqsRecommendedAlarmsFromAspectApproximateAgeOfOldestMessageAlarm76671054": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm watches the age of the oldest message in the queue. You can use this alarm to monitor if your consumers are processing SQS messages at the desired speed. Consider increasing the consumer count or consumer throughput to reduce message age. This metric can be used in combination with ApproximateNumberOfMessagesVisible to determine how big the queue backlog is and how quickly messages are being processed. To prevent messages from being deleted before processed, consider configuring the dead-letter queue to sideline potential poison pill messages.",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Fn::GetAtt": Array [
+                  "dlq09C78ACC",
+                  "QueueName",
+                ],
+              },
+              " - ApproximateAgeOfOldestMessage",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 15,
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "dlq09C78ACC",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 15,
+        "MetricName": "ApproximateAgeOfOldestMessage",
+        "Namespace": "AWS/SQS",
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "dlqSqsRecommendedAlarmsFromAspectApproximateNumberOfMessagesNotVisibleAlarm491DE0EA": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm helps to detect a high number of in-flight messages with respect to QueueName. For troubleshooting, check message backlog decreasing (https://repost.aws/knowledge-center/sqs-message-backlog).",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Fn::GetAtt": Array [
+                  "dlq09C78ACC",
+                  "QueueName",
+                ],
+              },
+              " - ApproximateNumberOfMessagesNotVisible",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 15,
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "dlq09C78ACC",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 15,
+        "MetricName": "ApproximateNumberOfMessagesNotVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "dlqSqsRecommendedAlarmsFromAspectApproximateNumberOfMessagesVisibleAlarm0C9FE60A": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm watches for the message queue backlog to be bigger than expected, indicating that consumers are too slow or there are not enough consumers.",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Fn::GetAtt": Array [
+                  "dlq09C78ACC",
+                  "QueueName",
+                ],
+              },
+              " - ApproximateNumberOfMessagesVisible",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 15,
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "dlq09C78ACC",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 15,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 60,
+        "Statistic": "Maximum",
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "dlqSqsRecommendedAlarmsFromAspectNumberOfMessagesSentAlarmFDCD6CDD": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm helps to detect if there are no messages being sent from a producer with respect to QueueName.",
+        "AlarmName": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              Object {
+                "Fn::GetAtt": Array [
+                  "dlq09C78ACC",
+                  "QueueName",
+                ],
+              },
+              " - NumberOfMessagesSent",
+            ],
+          ],
+        },
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "DatapointsToAlarm": 15,
+        "Dimensions": Array [
+          Object {
+            "Name": "QueueName",
+            "Value": Object {
+              "Fn::GetAtt": Array [
+                "dlq09C78ACC",
                 "QueueName",
               ],
             },


### PR DESCRIPTION
This adds the functionality to the library to exclude specific resources based on their `id` string provided in the stack. This should allow straightforward exclusions without the need to leverage any additional tagging, metadata, or other mechanisms by leveraging the already existing construct IDs.