### PR TITLE
feat: Implementing ApiGateway recommended alarms using the aspect construct

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,6 +2,2500 @@
 
 ## Constructs <a name="Constructs" id="Constructs"></a>
 
+### ApiGatewayRestApi4XXErrorAlarm <a name="ApiGatewayRestApi4XXErrorAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm"></a>
+
+This alarm detects a high rate of client-side errors.
+
+This can indicate an issue in the authorization or client request parameters. It could also mean that a resource was
+removed or a client is requesting one that doesn't exist. Consider enabling CloudWatch Logs and checking for any errors
+that may be causing the 4XX errors. Moreover, consider enabling detailed CloudWatch metrics to view this metric per
+resource and method and narrow down the source of the errors. Errors could also be caused by exceeding the configured
+throttling limit.
+
+The alarm is triggered when percentage of client-errors exceeds the threshold.
+
+#### Initializers <a name="Initializers" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApi4XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+new ApiGatewayRestApi4XXErrorAlarm(scope: IConstruct, id: string, props: ApiGatewayRestApi4XXErrorAlarmProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.Initializer.parameter.scope">scope</a></code> | <code>constructs.IConstruct</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.Initializer.parameter.props">props</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps">ApiGatewayRestApi4XXErrorAlarmProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps">ApiGatewayRestApi4XXErrorAlarmProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.addAlarmAction">addAlarmAction</a></code> | Trigger this action if the alarm fires. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.addInsufficientDataAction">addInsufficientDataAction</a></code> | Trigger this action if there is insufficient data to evaluate the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.addOkAction">addOkAction</a></code> | Trigger this action if the alarm returns from breaching state into ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.renderAlarmRule">renderAlarmRule</a></code> | AlarmRule indicating ALARM state for Alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.toAnnotation">toAnnotation</a></code> | Turn this alarm into a horizontal annotation. |
+
+---
+
+##### `toString` <a name="toString" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.applyRemovalPolicy"></a>
+
+```typescript
+public applyRemovalPolicy(policy: RemovalPolicy): void
+```
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
+account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
+
+###### `policy`<sup>Required</sup> <a name="policy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+---
+
+##### `addAlarmAction` <a name="addAlarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.addAlarmAction"></a>
+
+```typescript
+public addAlarmAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm fires.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.addAlarmAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addInsufficientDataAction` <a name="addInsufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.addInsufficientDataAction"></a>
+
+```typescript
+public addInsufficientDataAction(actions: IAlarmAction): void
+```
+
+Trigger this action if there is insufficient data to evaluate the alarm.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.addInsufficientDataAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addOkAction` <a name="addOkAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.addOkAction"></a>
+
+```typescript
+public addOkAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm returns from breaching state into ok state.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.addOkAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `renderAlarmRule` <a name="renderAlarmRule" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.renderAlarmRule"></a>
+
+```typescript
+public renderAlarmRule(): string
+```
+
+AlarmRule indicating ALARM state for Alarm.
+
+##### `toAnnotation` <a name="toAnnotation" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.toAnnotation"></a>
+
+```typescript
+public toAnnotation(): HorizontalAnnotation
+```
+
+Turn this alarm into a horizontal annotation.
+
+This is useful if you want to represent an Alarm in a non-AlarmWidget.
+An `AlarmWidget` can directly show an alarm, but it can only show a
+single alarm and no other metrics. Instead, you can convert the alarm to
+a HorizontalAnnotation and add it as an annotation to another graph.
+
+This might be useful if:
+
+- You want to show multiple alarms inside a single graph, for example if
+  you have both a "small margin/long period" alarm as well as a
+  "large margin/short period" alarm.
+
+- You want to show an Alarm line in a graph with multiple metrics in it.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.isOwnedResource">isOwnedResource</a></code> | Returns true if the construct was created by CDK, and false otherwise. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.fromAlarmArn">fromAlarmArn</a></code> | Import an existing CloudWatch alarm provided an ARN. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.fromAlarmName">fromAlarmName</a></code> | Import an existing CloudWatch alarm provided an Name. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.isConstruct"></a>
+
+```typescript
+import { ApiGatewayRestApi4XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApi4XXErrorAlarm.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isOwnedResource` <a name="isOwnedResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.isOwnedResource"></a>
+
+```typescript
+import { ApiGatewayRestApi4XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApi4XXErrorAlarm.isOwnedResource(construct: IConstruct)
+```
+
+Returns true if the construct was created by CDK, and false otherwise.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.isOwnedResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `isResource` <a name="isResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.isResource"></a>
+
+```typescript
+import { ApiGatewayRestApi4XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApi4XXErrorAlarm.isResource(construct: IConstruct)
+```
+
+Check whether the given construct is a Resource.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.isResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `fromAlarmArn` <a name="fromAlarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.fromAlarmArn"></a>
+
+```typescript
+import { ApiGatewayRestApi4XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApi4XXErrorAlarm.fromAlarmArn(scope: Construct, id: string, alarmArn: string)
+```
+
+Import an existing CloudWatch alarm provided an ARN.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.fromAlarmArn.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.fromAlarmArn.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.fromAlarmArn.parameter.alarmArn"></a>
+
+- *Type:* string
+
+Alarm ARN (i.e. arn:aws:cloudwatch:<region>:<account-id>:alarm:Foo).
+
+---
+
+##### `fromAlarmName` <a name="fromAlarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.fromAlarmName"></a>
+
+```typescript
+import { ApiGatewayRestApi4XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApi4XXErrorAlarm.fromAlarmName(scope: Construct, id: string, alarmName: string)
+```
+
+Import an existing CloudWatch alarm provided an Name.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.fromAlarmName.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.fromAlarmName.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.fromAlarmName.parameter.alarmName"></a>
+
+- *Type:* string
+
+Alarm Name.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.alarmArn">alarmArn</a></code> | <code>string</code> | ARN of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.alarmName">alarmName</a></code> | <code>string</code> | Name of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.metric">metric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IMetric</code> | The metric object this alarm was based on. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `env`<sup>Required</sup> <a name="env" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.env"></a>
+
+```typescript
+public readonly env: ResourceEnvironment;
+```
+
+- *Type:* aws-cdk-lib.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### `stack`<sup>Required</sup> <a name="stack" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.alarmArn"></a>
+
+```typescript
+public readonly alarmArn: string;
+```
+
+- *Type:* string
+
+ARN of this alarm.
+
+---
+
+##### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+
+Name of this alarm.
+
+---
+
+##### `metric`<sup>Required</sup> <a name="metric" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm.property.metric"></a>
+
+```typescript
+public readonly metric: IMetric;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IMetric
+
+The metric object this alarm was based on.
+
+---
+
+
+### ApiGatewayRestApi5XXErrorAlarm <a name="ApiGatewayRestApi5XXErrorAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm"></a>
+
+This alarm detects a high rate of server-side errors.
+
+This can indicate that there is something wrong on the API backend, the network,
+or the integration between the API gateway and the backend API.
+
+The alarm is triggered when percentage of server-errors exceeds the threshold.
+
+#### Initializers <a name="Initializers" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApi5XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+new ApiGatewayRestApi5XXErrorAlarm(scope: IConstruct, id: string, props: ApiGatewayRestApi5XXErrorAlarmProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.Initializer.parameter.scope">scope</a></code> | <code>constructs.IConstruct</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.Initializer.parameter.props">props</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps">ApiGatewayRestApi5XXErrorAlarmProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps">ApiGatewayRestApi5XXErrorAlarmProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.addAlarmAction">addAlarmAction</a></code> | Trigger this action if the alarm fires. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.addInsufficientDataAction">addInsufficientDataAction</a></code> | Trigger this action if there is insufficient data to evaluate the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.addOkAction">addOkAction</a></code> | Trigger this action if the alarm returns from breaching state into ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.renderAlarmRule">renderAlarmRule</a></code> | AlarmRule indicating ALARM state for Alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.toAnnotation">toAnnotation</a></code> | Turn this alarm into a horizontal annotation. |
+
+---
+
+##### `toString` <a name="toString" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.applyRemovalPolicy"></a>
+
+```typescript
+public applyRemovalPolicy(policy: RemovalPolicy): void
+```
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
+account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
+
+###### `policy`<sup>Required</sup> <a name="policy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+---
+
+##### `addAlarmAction` <a name="addAlarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.addAlarmAction"></a>
+
+```typescript
+public addAlarmAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm fires.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.addAlarmAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addInsufficientDataAction` <a name="addInsufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.addInsufficientDataAction"></a>
+
+```typescript
+public addInsufficientDataAction(actions: IAlarmAction): void
+```
+
+Trigger this action if there is insufficient data to evaluate the alarm.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.addInsufficientDataAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addOkAction` <a name="addOkAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.addOkAction"></a>
+
+```typescript
+public addOkAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm returns from breaching state into ok state.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.addOkAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `renderAlarmRule` <a name="renderAlarmRule" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.renderAlarmRule"></a>
+
+```typescript
+public renderAlarmRule(): string
+```
+
+AlarmRule indicating ALARM state for Alarm.
+
+##### `toAnnotation` <a name="toAnnotation" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.toAnnotation"></a>
+
+```typescript
+public toAnnotation(): HorizontalAnnotation
+```
+
+Turn this alarm into a horizontal annotation.
+
+This is useful if you want to represent an Alarm in a non-AlarmWidget.
+An `AlarmWidget` can directly show an alarm, but it can only show a
+single alarm and no other metrics. Instead, you can convert the alarm to
+a HorizontalAnnotation and add it as an annotation to another graph.
+
+This might be useful if:
+
+- You want to show multiple alarms inside a single graph, for example if
+  you have both a "small margin/long period" alarm as well as a
+  "large margin/short period" alarm.
+
+- You want to show an Alarm line in a graph with multiple metrics in it.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.isOwnedResource">isOwnedResource</a></code> | Returns true if the construct was created by CDK, and false otherwise. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.fromAlarmArn">fromAlarmArn</a></code> | Import an existing CloudWatch alarm provided an ARN. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.fromAlarmName">fromAlarmName</a></code> | Import an existing CloudWatch alarm provided an Name. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.isConstruct"></a>
+
+```typescript
+import { ApiGatewayRestApi5XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApi5XXErrorAlarm.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isOwnedResource` <a name="isOwnedResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.isOwnedResource"></a>
+
+```typescript
+import { ApiGatewayRestApi5XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApi5XXErrorAlarm.isOwnedResource(construct: IConstruct)
+```
+
+Returns true if the construct was created by CDK, and false otherwise.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.isOwnedResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `isResource` <a name="isResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.isResource"></a>
+
+```typescript
+import { ApiGatewayRestApi5XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApi5XXErrorAlarm.isResource(construct: IConstruct)
+```
+
+Check whether the given construct is a Resource.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.isResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `fromAlarmArn` <a name="fromAlarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.fromAlarmArn"></a>
+
+```typescript
+import { ApiGatewayRestApi5XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApi5XXErrorAlarm.fromAlarmArn(scope: Construct, id: string, alarmArn: string)
+```
+
+Import an existing CloudWatch alarm provided an ARN.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.fromAlarmArn.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.fromAlarmArn.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.fromAlarmArn.parameter.alarmArn"></a>
+
+- *Type:* string
+
+Alarm ARN (i.e. arn:aws:cloudwatch:<region>:<account-id>:alarm:Foo).
+
+---
+
+##### `fromAlarmName` <a name="fromAlarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.fromAlarmName"></a>
+
+```typescript
+import { ApiGatewayRestApi5XXErrorAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApi5XXErrorAlarm.fromAlarmName(scope: Construct, id: string, alarmName: string)
+```
+
+Import an existing CloudWatch alarm provided an Name.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.fromAlarmName.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.fromAlarmName.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.fromAlarmName.parameter.alarmName"></a>
+
+- *Type:* string
+
+Alarm Name.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.alarmArn">alarmArn</a></code> | <code>string</code> | ARN of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.alarmName">alarmName</a></code> | <code>string</code> | Name of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.metric">metric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IMetric</code> | The metric object this alarm was based on. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `env`<sup>Required</sup> <a name="env" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.env"></a>
+
+```typescript
+public readonly env: ResourceEnvironment;
+```
+
+- *Type:* aws-cdk-lib.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### `stack`<sup>Required</sup> <a name="stack" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.alarmArn"></a>
+
+```typescript
+public readonly alarmArn: string;
+```
+
+- *Type:* string
+
+ARN of this alarm.
+
+---
+
+##### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+
+Name of this alarm.
+
+---
+
+##### `metric`<sup>Required</sup> <a name="metric" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm.property.metric"></a>
+
+```typescript
+public readonly metric: IMetric;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IMetric
+
+The metric object this alarm was based on.
+
+---
+
+
+### ApiGatewayRestApiCountAlarm <a name="ApiGatewayRestApiCountAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm"></a>
+
+This alarm helps to detect low traffic volume for the REST API stage.
+
+This can be an indicator of an issue with the application calling the API such as using incorrect endpoints.
+It could also be an indicator of an issue with the configuration or permissions of the API making it unreachable
+for clients.
+
+The alarm is triggered when the number of requests in a given period is less than threshold.
+
+#### Initializers <a name="Initializers" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+new ApiGatewayRestApiCountAlarm(scope: IConstruct, id: string, props: ApiGatewayRestApiCountAlarmProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.Initializer.parameter.scope">scope</a></code> | <code>constructs.IConstruct</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.Initializer.parameter.props">props</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps">ApiGatewayRestApiCountAlarmProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps">ApiGatewayRestApiCountAlarmProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.addAlarmAction">addAlarmAction</a></code> | Trigger this action if the alarm fires. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.addInsufficientDataAction">addInsufficientDataAction</a></code> | Trigger this action if there is insufficient data to evaluate the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.addOkAction">addOkAction</a></code> | Trigger this action if the alarm returns from breaching state into ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.renderAlarmRule">renderAlarmRule</a></code> | AlarmRule indicating ALARM state for Alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.toAnnotation">toAnnotation</a></code> | Turn this alarm into a horizontal annotation. |
+
+---
+
+##### `toString` <a name="toString" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.applyRemovalPolicy"></a>
+
+```typescript
+public applyRemovalPolicy(policy: RemovalPolicy): void
+```
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
+account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
+
+###### `policy`<sup>Required</sup> <a name="policy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+---
+
+##### `addAlarmAction` <a name="addAlarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.addAlarmAction"></a>
+
+```typescript
+public addAlarmAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm fires.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.addAlarmAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addInsufficientDataAction` <a name="addInsufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.addInsufficientDataAction"></a>
+
+```typescript
+public addInsufficientDataAction(actions: IAlarmAction): void
+```
+
+Trigger this action if there is insufficient data to evaluate the alarm.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.addInsufficientDataAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addOkAction` <a name="addOkAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.addOkAction"></a>
+
+```typescript
+public addOkAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm returns from breaching state into ok state.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.addOkAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `renderAlarmRule` <a name="renderAlarmRule" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.renderAlarmRule"></a>
+
+```typescript
+public renderAlarmRule(): string
+```
+
+AlarmRule indicating ALARM state for Alarm.
+
+##### `toAnnotation` <a name="toAnnotation" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.toAnnotation"></a>
+
+```typescript
+public toAnnotation(): HorizontalAnnotation
+```
+
+Turn this alarm into a horizontal annotation.
+
+This is useful if you want to represent an Alarm in a non-AlarmWidget.
+An `AlarmWidget` can directly show an alarm, but it can only show a
+single alarm and no other metrics. Instead, you can convert the alarm to
+a HorizontalAnnotation and add it as an annotation to another graph.
+
+This might be useful if:
+
+- You want to show multiple alarms inside a single graph, for example if
+  you have both a "small margin/long period" alarm as well as a
+  "large margin/short period" alarm.
+
+- You want to show an Alarm line in a graph with multiple metrics in it.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.isOwnedResource">isOwnedResource</a></code> | Returns true if the construct was created by CDK, and false otherwise. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.fromAlarmArn">fromAlarmArn</a></code> | Import an existing CloudWatch alarm provided an ARN. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.fromAlarmName">fromAlarmName</a></code> | Import an existing CloudWatch alarm provided an Name. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.isConstruct"></a>
+
+```typescript
+import { ApiGatewayRestApiCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiCountAlarm.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isOwnedResource` <a name="isOwnedResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.isOwnedResource"></a>
+
+```typescript
+import { ApiGatewayRestApiCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiCountAlarm.isOwnedResource(construct: IConstruct)
+```
+
+Returns true if the construct was created by CDK, and false otherwise.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.isOwnedResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `isResource` <a name="isResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.isResource"></a>
+
+```typescript
+import { ApiGatewayRestApiCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiCountAlarm.isResource(construct: IConstruct)
+```
+
+Check whether the given construct is a Resource.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.isResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `fromAlarmArn` <a name="fromAlarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.fromAlarmArn"></a>
+
+```typescript
+import { ApiGatewayRestApiCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiCountAlarm.fromAlarmArn(scope: Construct, id: string, alarmArn: string)
+```
+
+Import an existing CloudWatch alarm provided an ARN.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.fromAlarmArn.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.fromAlarmArn.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.fromAlarmArn.parameter.alarmArn"></a>
+
+- *Type:* string
+
+Alarm ARN (i.e. arn:aws:cloudwatch:<region>:<account-id>:alarm:Foo).
+
+---
+
+##### `fromAlarmName` <a name="fromAlarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.fromAlarmName"></a>
+
+```typescript
+import { ApiGatewayRestApiCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiCountAlarm.fromAlarmName(scope: Construct, id: string, alarmName: string)
+```
+
+Import an existing CloudWatch alarm provided an Name.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.fromAlarmName.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.fromAlarmName.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.fromAlarmName.parameter.alarmName"></a>
+
+- *Type:* string
+
+Alarm Name.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.alarmArn">alarmArn</a></code> | <code>string</code> | ARN of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.alarmName">alarmName</a></code> | <code>string</code> | Name of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.metric">metric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IMetric</code> | The metric object this alarm was based on. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `env`<sup>Required</sup> <a name="env" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.env"></a>
+
+```typescript
+public readonly env: ResourceEnvironment;
+```
+
+- *Type:* aws-cdk-lib.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### `stack`<sup>Required</sup> <a name="stack" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.alarmArn"></a>
+
+```typescript
+public readonly alarmArn: string;
+```
+
+- *Type:* string
+
+ARN of this alarm.
+
+---
+
+##### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+
+Name of this alarm.
+
+---
+
+##### `metric`<sup>Required</sup> <a name="metric" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm.property.metric"></a>
+
+```typescript
+public readonly metric: IMetric;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IMetric
+
+The metric object this alarm was based on.
+
+---
+
+
+### ApiGatewayRestApiDetailedCountAlarm <a name="ApiGatewayRestApiDetailedCountAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm"></a>
+
+This alarm can detect unexpectedly low traffic volume for the REST API resource and method in the stage.
+
+We recommend that you create this alarm if your API receives a predictable and
+consistent number of requests under normal conditions. This alarm is not recommended for APIs
+that don't expect constant and consistent traffic.
+
+The alarm is triggered when the number of requests in a given period is less than threshold.
+
+#### Initializers <a name="Initializers" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+new ApiGatewayRestApiDetailedCountAlarm(scope: IConstruct, id: string, props: ApiGatewayRestApiDetailedCountAlarmProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.Initializer.parameter.scope">scope</a></code> | <code>constructs.IConstruct</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.Initializer.parameter.props">props</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps">ApiGatewayRestApiDetailedCountAlarmProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps">ApiGatewayRestApiDetailedCountAlarmProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.addAlarmAction">addAlarmAction</a></code> | Trigger this action if the alarm fires. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.addInsufficientDataAction">addInsufficientDataAction</a></code> | Trigger this action if there is insufficient data to evaluate the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.addOkAction">addOkAction</a></code> | Trigger this action if the alarm returns from breaching state into ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.renderAlarmRule">renderAlarmRule</a></code> | AlarmRule indicating ALARM state for Alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.toAnnotation">toAnnotation</a></code> | Turn this alarm into a horizontal annotation. |
+
+---
+
+##### `toString` <a name="toString" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.applyRemovalPolicy"></a>
+
+```typescript
+public applyRemovalPolicy(policy: RemovalPolicy): void
+```
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
+account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
+
+###### `policy`<sup>Required</sup> <a name="policy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+---
+
+##### `addAlarmAction` <a name="addAlarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.addAlarmAction"></a>
+
+```typescript
+public addAlarmAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm fires.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.addAlarmAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addInsufficientDataAction` <a name="addInsufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.addInsufficientDataAction"></a>
+
+```typescript
+public addInsufficientDataAction(actions: IAlarmAction): void
+```
+
+Trigger this action if there is insufficient data to evaluate the alarm.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.addInsufficientDataAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addOkAction` <a name="addOkAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.addOkAction"></a>
+
+```typescript
+public addOkAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm returns from breaching state into ok state.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.addOkAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `renderAlarmRule` <a name="renderAlarmRule" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.renderAlarmRule"></a>
+
+```typescript
+public renderAlarmRule(): string
+```
+
+AlarmRule indicating ALARM state for Alarm.
+
+##### `toAnnotation` <a name="toAnnotation" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.toAnnotation"></a>
+
+```typescript
+public toAnnotation(): HorizontalAnnotation
+```
+
+Turn this alarm into a horizontal annotation.
+
+This is useful if you want to represent an Alarm in a non-AlarmWidget.
+An `AlarmWidget` can directly show an alarm, but it can only show a
+single alarm and no other metrics. Instead, you can convert the alarm to
+a HorizontalAnnotation and add it as an annotation to another graph.
+
+This might be useful if:
+
+- You want to show multiple alarms inside a single graph, for example if
+  you have both a "small margin/long period" alarm as well as a
+  "large margin/short period" alarm.
+
+- You want to show an Alarm line in a graph with multiple metrics in it.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.isOwnedResource">isOwnedResource</a></code> | Returns true if the construct was created by CDK, and false otherwise. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.fromAlarmArn">fromAlarmArn</a></code> | Import an existing CloudWatch alarm provided an ARN. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.fromAlarmName">fromAlarmName</a></code> | Import an existing CloudWatch alarm provided an Name. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.isConstruct"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiDetailedCountAlarm.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isOwnedResource` <a name="isOwnedResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.isOwnedResource"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiDetailedCountAlarm.isOwnedResource(construct: IConstruct)
+```
+
+Returns true if the construct was created by CDK, and false otherwise.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.isOwnedResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `isResource` <a name="isResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.isResource"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiDetailedCountAlarm.isResource(construct: IConstruct)
+```
+
+Check whether the given construct is a Resource.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.isResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `fromAlarmArn` <a name="fromAlarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.fromAlarmArn"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiDetailedCountAlarm.fromAlarmArn(scope: Construct, id: string, alarmArn: string)
+```
+
+Import an existing CloudWatch alarm provided an ARN.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.fromAlarmArn.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.fromAlarmArn.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.fromAlarmArn.parameter.alarmArn"></a>
+
+- *Type:* string
+
+Alarm ARN (i.e. arn:aws:cloudwatch:<region>:<account-id>:alarm:Foo).
+
+---
+
+##### `fromAlarmName` <a name="fromAlarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.fromAlarmName"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedCountAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiDetailedCountAlarm.fromAlarmName(scope: Construct, id: string, alarmName: string)
+```
+
+Import an existing CloudWatch alarm provided an Name.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.fromAlarmName.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.fromAlarmName.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.fromAlarmName.parameter.alarmName"></a>
+
+- *Type:* string
+
+Alarm Name.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.alarmArn">alarmArn</a></code> | <code>string</code> | ARN of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.alarmName">alarmName</a></code> | <code>string</code> | Name of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.metric">metric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IMetric</code> | The metric object this alarm was based on. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `env`<sup>Required</sup> <a name="env" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.env"></a>
+
+```typescript
+public readonly env: ResourceEnvironment;
+```
+
+- *Type:* aws-cdk-lib.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### `stack`<sup>Required</sup> <a name="stack" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.alarmArn"></a>
+
+```typescript
+public readonly alarmArn: string;
+```
+
+- *Type:* string
+
+ARN of this alarm.
+
+---
+
+##### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+
+Name of this alarm.
+
+---
+
+##### `metric`<sup>Required</sup> <a name="metric" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarm.property.metric"></a>
+
+```typescript
+public readonly metric: IMetric;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IMetric
+
+The metric object this alarm was based on.
+
+---
+
+
+### ApiGatewayRestApiDetailedLatencyAlarm <a name="ApiGatewayRestApiDetailedLatencyAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm"></a>
+
+This alarm detects high latency for a resource and method in a stage.
+
+Find the IntegrationLatency metric value to check the API backend latency. If the two
+metrics are mostly aligned, the API backend is the source of higher latency and you should
+investigate there for performance issues. Consider also enabling CloudWatch Logs and checking
+for any errors that might be causing the high latency.
+
+The alarm is triggered when time in milliseconds exceeds or equals the threshold.
+
+#### Initializers <a name="Initializers" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+new ApiGatewayRestApiDetailedLatencyAlarm(scope: IConstruct, id: string, props: ApiGatewayRestApiDetailedLatencyAlarmProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.Initializer.parameter.scope">scope</a></code> | <code>constructs.IConstruct</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.Initializer.parameter.props">props</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps">ApiGatewayRestApiDetailedLatencyAlarmProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps">ApiGatewayRestApiDetailedLatencyAlarmProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.addAlarmAction">addAlarmAction</a></code> | Trigger this action if the alarm fires. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.addInsufficientDataAction">addInsufficientDataAction</a></code> | Trigger this action if there is insufficient data to evaluate the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.addOkAction">addOkAction</a></code> | Trigger this action if the alarm returns from breaching state into ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.renderAlarmRule">renderAlarmRule</a></code> | AlarmRule indicating ALARM state for Alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.toAnnotation">toAnnotation</a></code> | Turn this alarm into a horizontal annotation. |
+
+---
+
+##### `toString` <a name="toString" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.applyRemovalPolicy"></a>
+
+```typescript
+public applyRemovalPolicy(policy: RemovalPolicy): void
+```
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
+account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
+
+###### `policy`<sup>Required</sup> <a name="policy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+---
+
+##### `addAlarmAction` <a name="addAlarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.addAlarmAction"></a>
+
+```typescript
+public addAlarmAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm fires.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.addAlarmAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addInsufficientDataAction` <a name="addInsufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.addInsufficientDataAction"></a>
+
+```typescript
+public addInsufficientDataAction(actions: IAlarmAction): void
+```
+
+Trigger this action if there is insufficient data to evaluate the alarm.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.addInsufficientDataAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addOkAction` <a name="addOkAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.addOkAction"></a>
+
+```typescript
+public addOkAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm returns from breaching state into ok state.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.addOkAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `renderAlarmRule` <a name="renderAlarmRule" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.renderAlarmRule"></a>
+
+```typescript
+public renderAlarmRule(): string
+```
+
+AlarmRule indicating ALARM state for Alarm.
+
+##### `toAnnotation` <a name="toAnnotation" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.toAnnotation"></a>
+
+```typescript
+public toAnnotation(): HorizontalAnnotation
+```
+
+Turn this alarm into a horizontal annotation.
+
+This is useful if you want to represent an Alarm in a non-AlarmWidget.
+An `AlarmWidget` can directly show an alarm, but it can only show a
+single alarm and no other metrics. Instead, you can convert the alarm to
+a HorizontalAnnotation and add it as an annotation to another graph.
+
+This might be useful if:
+
+- You want to show multiple alarms inside a single graph, for example if
+  you have both a "small margin/long period" alarm as well as a
+  "large margin/short period" alarm.
+
+- You want to show an Alarm line in a graph with multiple metrics in it.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.isOwnedResource">isOwnedResource</a></code> | Returns true if the construct was created by CDK, and false otherwise. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmArn">fromAlarmArn</a></code> | Import an existing CloudWatch alarm provided an ARN. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmName">fromAlarmName</a></code> | Import an existing CloudWatch alarm provided an Name. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.isConstruct"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiDetailedLatencyAlarm.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isOwnedResource` <a name="isOwnedResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.isOwnedResource"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiDetailedLatencyAlarm.isOwnedResource(construct: IConstruct)
+```
+
+Returns true if the construct was created by CDK, and false otherwise.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.isOwnedResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `isResource` <a name="isResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.isResource"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiDetailedLatencyAlarm.isResource(construct: IConstruct)
+```
+
+Check whether the given construct is a Resource.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.isResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `fromAlarmArn` <a name="fromAlarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmArn"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmArn(scope: Construct, id: string, alarmArn: string)
+```
+
+Import an existing CloudWatch alarm provided an ARN.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmArn.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmArn.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmArn.parameter.alarmArn"></a>
+
+- *Type:* string
+
+Alarm ARN (i.e. arn:aws:cloudwatch:<region>:<account-id>:alarm:Foo).
+
+---
+
+##### `fromAlarmName` <a name="fromAlarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmName"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmName(scope: Construct, id: string, alarmName: string)
+```
+
+Import an existing CloudWatch alarm provided an Name.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmName.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmName.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.fromAlarmName.parameter.alarmName"></a>
+
+- *Type:* string
+
+Alarm Name.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.alarmArn">alarmArn</a></code> | <code>string</code> | ARN of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.alarmName">alarmName</a></code> | <code>string</code> | Name of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.metric">metric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IMetric</code> | The metric object this alarm was based on. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `env`<sup>Required</sup> <a name="env" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.env"></a>
+
+```typescript
+public readonly env: ResourceEnvironment;
+```
+
+- *Type:* aws-cdk-lib.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### `stack`<sup>Required</sup> <a name="stack" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.alarmArn"></a>
+
+```typescript
+public readonly alarmArn: string;
+```
+
+- *Type:* string
+
+ARN of this alarm.
+
+---
+
+##### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+
+Name of this alarm.
+
+---
+
+##### `metric`<sup>Required</sup> <a name="metric" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarm.property.metric"></a>
+
+```typescript
+public readonly metric: IMetric;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IMetric
+
+The metric object this alarm was based on.
+
+---
+
+
+### ApiGatewayRestApiLatencyAlarm <a name="ApiGatewayRestApiLatencyAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm"></a>
+
+This alarm can detect when the API Gateway requests in a stage have high latency.
+
+If you have detailed CloudWatch metrics enabled and you have different latency performance
+requirements for each method and resource, we recommend that you create alternative alarms to
+have more fine-grained monitoring of the latency for each resource and method.
+
+The alarm is triggered when time in milliseconds exceeds or equals the threshold.
+
+#### Initializers <a name="Initializers" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+new ApiGatewayRestApiLatencyAlarm(scope: IConstruct, id: string, props: ApiGatewayRestApiLatencyAlarmProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.Initializer.parameter.scope">scope</a></code> | <code>constructs.IConstruct</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.Initializer.parameter.props">props</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps">ApiGatewayRestApiLatencyAlarmProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps">ApiGatewayRestApiLatencyAlarmProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.addAlarmAction">addAlarmAction</a></code> | Trigger this action if the alarm fires. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.addInsufficientDataAction">addInsufficientDataAction</a></code> | Trigger this action if there is insufficient data to evaluate the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.addOkAction">addOkAction</a></code> | Trigger this action if the alarm returns from breaching state into ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.renderAlarmRule">renderAlarmRule</a></code> | AlarmRule indicating ALARM state for Alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.toAnnotation">toAnnotation</a></code> | Turn this alarm into a horizontal annotation. |
+
+---
+
+##### `toString` <a name="toString" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.applyRemovalPolicy"></a>
+
+```typescript
+public applyRemovalPolicy(policy: RemovalPolicy): void
+```
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
+account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
+
+###### `policy`<sup>Required</sup> <a name="policy" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+---
+
+##### `addAlarmAction` <a name="addAlarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.addAlarmAction"></a>
+
+```typescript
+public addAlarmAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm fires.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.addAlarmAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addInsufficientDataAction` <a name="addInsufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.addInsufficientDataAction"></a>
+
+```typescript
+public addInsufficientDataAction(actions: IAlarmAction): void
+```
+
+Trigger this action if there is insufficient data to evaluate the alarm.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.addInsufficientDataAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `addOkAction` <a name="addOkAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.addOkAction"></a>
+
+```typescript
+public addOkAction(actions: IAlarmAction): void
+```
+
+Trigger this action if the alarm returns from breaching state into ok state.
+
+Typically SnsAction or AutoScalingAction.
+
+###### `actions`<sup>Required</sup> <a name="actions" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.addOkAction.parameter.actions"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+
+---
+
+##### `renderAlarmRule` <a name="renderAlarmRule" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.renderAlarmRule"></a>
+
+```typescript
+public renderAlarmRule(): string
+```
+
+AlarmRule indicating ALARM state for Alarm.
+
+##### `toAnnotation` <a name="toAnnotation" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.toAnnotation"></a>
+
+```typescript
+public toAnnotation(): HorizontalAnnotation
+```
+
+Turn this alarm into a horizontal annotation.
+
+This is useful if you want to represent an Alarm in a non-AlarmWidget.
+An `AlarmWidget` can directly show an alarm, but it can only show a
+single alarm and no other metrics. Instead, you can convert the alarm to
+a HorizontalAnnotation and add it as an annotation to another graph.
+
+This might be useful if:
+
+- You want to show multiple alarms inside a single graph, for example if
+  you have both a "small margin/long period" alarm as well as a
+  "large margin/short period" alarm.
+
+- You want to show an Alarm line in a graph with multiple metrics in it.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.isOwnedResource">isOwnedResource</a></code> | Returns true if the construct was created by CDK, and false otherwise. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.fromAlarmArn">fromAlarmArn</a></code> | Import an existing CloudWatch alarm provided an ARN. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.fromAlarmName">fromAlarmName</a></code> | Import an existing CloudWatch alarm provided an Name. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.isConstruct"></a>
+
+```typescript
+import { ApiGatewayRestApiLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiLatencyAlarm.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isOwnedResource` <a name="isOwnedResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.isOwnedResource"></a>
+
+```typescript
+import { ApiGatewayRestApiLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiLatencyAlarm.isOwnedResource(construct: IConstruct)
+```
+
+Returns true if the construct was created by CDK, and false otherwise.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.isOwnedResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `isResource` <a name="isResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.isResource"></a>
+
+```typescript
+import { ApiGatewayRestApiLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiLatencyAlarm.isResource(construct: IConstruct)
+```
+
+Check whether the given construct is a Resource.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.isResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `fromAlarmArn` <a name="fromAlarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.fromAlarmArn"></a>
+
+```typescript
+import { ApiGatewayRestApiLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiLatencyAlarm.fromAlarmArn(scope: Construct, id: string, alarmArn: string)
+```
+
+Import an existing CloudWatch alarm provided an ARN.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.fromAlarmArn.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.fromAlarmArn.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.fromAlarmArn.parameter.alarmArn"></a>
+
+- *Type:* string
+
+Alarm ARN (i.e. arn:aws:cloudwatch:<region>:<account-id>:alarm:Foo).
+
+---
+
+##### `fromAlarmName` <a name="fromAlarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.fromAlarmName"></a>
+
+```typescript
+import { ApiGatewayRestApiLatencyAlarm } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiLatencyAlarm.fromAlarmName(scope: Construct, id: string, alarmName: string)
+```
+
+Import an existing CloudWatch alarm provided an Name.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.fromAlarmName.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The parent creating construct (usually `this`).
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.fromAlarmName.parameter.id"></a>
+
+- *Type:* string
+
+The construct's name.
+
+---
+
+###### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.fromAlarmName.parameter.alarmName"></a>
+
+- *Type:* string
+
+Alarm Name.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.alarmArn">alarmArn</a></code> | <code>string</code> | ARN of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.alarmName">alarmName</a></code> | <code>string</code> | Name of this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.metric">metric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IMetric</code> | The metric object this alarm was based on. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `env`<sup>Required</sup> <a name="env" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.env"></a>
+
+```typescript
+public readonly env: ResourceEnvironment;
+```
+
+- *Type:* aws-cdk-lib.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### `stack`<sup>Required</sup> <a name="stack" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### `alarmArn`<sup>Required</sup> <a name="alarmArn" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.alarmArn"></a>
+
+```typescript
+public readonly alarmArn: string;
+```
+
+- *Type:* string
+
+ARN of this alarm.
+
+---
+
+##### `alarmName`<sup>Required</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+
+Name of this alarm.
+
+---
+
+##### `metric`<sup>Required</sup> <a name="metric" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm.property.metric"></a>
+
+```typescript
+public readonly metric: IMetric;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IMetric
+
+The metric object this alarm was based on.
+
+---
+
+
+### ApiGatewayRestApiRecommendedAlarms <a name="ApiGatewayRestApiRecommendedAlarms" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms"></a>
+
+A construct that creates the recommended alarms for an ApiGateway api.
+
+The recommended alarms created by default for the ApiName and Stage are:
+- 4XXError alarm
+- 5XXError alarm
+- Count alarm
+- Latency alarm
+
+In order to create the Count or Latency alarms for the Resource and Method dimensions the
+configDetailedCountAlarmList or configDetailedLatencyAlarmList must be specified.
+
+> [https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#ApiGateway](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#ApiGateway)
+
+#### Initializers <a name="Initializers" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiRecommendedAlarms } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+new ApiGatewayRestApiRecommendedAlarms(scope: Construct, id: string, props: ApiGatewayRestApiRecommendedAlarmsProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.Initializer.parameter.props">props</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps">ApiGatewayRestApiRecommendedAlarmsProps</a></code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps">ApiGatewayRestApiRecommendedAlarmsProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.toString">toString</a></code> | Returns a string representation of this construct. |
+
+---
+
+##### `toString` <a name="toString" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.isConstruct"></a>
+
+```typescript
+import { ApiGatewayRestApiRecommendedAlarms } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+ApiGatewayRestApiRecommendedAlarms.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.property.alarm4XXError">alarm4XXError</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm">ApiGatewayRestApi4XXErrorAlarm</a></code> | The 4XXError alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.property.alarm5XXError">alarm5XXError</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm">ApiGatewayRestApi5XXErrorAlarm</a></code> | The 5XXError alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.property.alarmCount">alarmCount</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm">ApiGatewayRestApiCountAlarm</a></code> | The Count alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.property.alarmLatency">alarmLatency</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm">ApiGatewayRestApiLatencyAlarm</a></code> | The Latency alarm. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `alarm4XXError`<sup>Optional</sup> <a name="alarm4XXError" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.property.alarm4XXError"></a>
+
+```typescript
+public readonly alarm4XXError: ApiGatewayRestApi4XXErrorAlarm;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarm">ApiGatewayRestApi4XXErrorAlarm</a>
+
+The 4XXError alarm.
+
+---
+
+##### `alarm5XXError`<sup>Optional</sup> <a name="alarm5XXError" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.property.alarm5XXError"></a>
+
+```typescript
+public readonly alarm5XXError: ApiGatewayRestApi5XXErrorAlarm;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarm">ApiGatewayRestApi5XXErrorAlarm</a>
+
+The 5XXError alarm.
+
+---
+
+##### `alarmCount`<sup>Optional</sup> <a name="alarmCount" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.property.alarmCount"></a>
+
+```typescript
+public readonly alarmCount: ApiGatewayRestApiCountAlarm;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarm">ApiGatewayRestApiCountAlarm</a>
+
+The Count alarm.
+
+---
+
+##### `alarmLatency`<sup>Optional</sup> <a name="alarmLatency" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarms.property.alarmLatency"></a>
+
+```typescript
+public readonly alarmLatency: ApiGatewayRestApiLatencyAlarm;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarm">ApiGatewayRestApiLatencyAlarm</a>
+
+The Latency alarm.
+
+---
+
+
 ### Bucket <a name="Bucket" id="@renovosolutions/cdk-library-cloudwatch-alarms.Bucket"></a>
 
 An extension for the S3 Bucket construct that provides methods to create recommended alarms.
@@ -14416,6 +16910,822 @@ The metric object this alarm was based on.
 ---
 
 
+### RestApi <a name="RestApi" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi"></a>
+
+An extension for the RestApi construct that provides methods to create recommended alarms.
+
+#### Initializers <a name="Initializers" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.Initializer"></a>
+
+```typescript
+import { RestApi } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+new RestApi(scope: Construct, id: string, props: RestApiBaseProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.Initializer.parameter.props">props</a></code> | <code>aws-cdk-lib.aws_apigateway.RestApiBaseProps</code> | *No description.* |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.Initializer.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_apigateway.RestApiBaseProps
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addApiKey">addApiKey</a></code> | Add an ApiKey to the deploymentStage. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addDomainName">addDomainName</a></code> | Defines an API Gateway domain name and maps it to this API. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addGatewayResponse">addGatewayResponse</a></code> | Adds a new gateway response. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addUsagePlan">addUsagePlan</a></code> | Adds a usage plan. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.arnForExecuteApi">arnForExecuteApi</a></code> | Gets the "execute-api" ARN. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metric">metric</a></code> | Returns the given named metric for this API. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricCacheHitCount">metricCacheHitCount</a></code> | Metric for the number of requests served from the API cache in a given period. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricCacheMissCount">metricCacheMissCount</a></code> | Metric for the number of requests served from the backend in a given period, when API caching is enabled. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricClientError">metricClientError</a></code> | Metric for the number of client-side errors captured in a given period. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricCount">metricCount</a></code> | Metric for the total number API requests in a given period. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricIntegrationLatency">metricIntegrationLatency</a></code> | Metric for the time between when API Gateway relays a request to the backend and when it receives a response from the backend. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricLatency">metricLatency</a></code> | The time between when API Gateway receives a request from a client and when it returns a response to the client. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricServerError">metricServerError</a></code> | Metric for the number of server-side errors captured in a given period. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.urlForPath">urlForPath</a></code> | Returns the URL for an HTTP path. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addModel">addModel</a></code> | Adds a new model. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addRequestValidator">addRequestValidator</a></code> | Adds a new request validator. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarm4XXError">alarm4XXError</a></code> | Creates an alarm that monitors the number of client-side errors captured in a given period. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarm5XXError">alarm5XXError</a></code> | Creates an alarm that monitors the number of server-side errors captured in a given period. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmCount">alarmCount</a></code> | Creates an alarm that monitors the total number API requests in a given period. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmDetailedCount">alarmDetailedCount</a></code> | Creates a list of alarms that monitor the total number API requests in a given period for the methods and resources specified. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmDetailedLatency">alarmDetailedLatency</a></code> | Creates a list of alarms the time between when API Gateway receives a request from a client and when it returns a response to the client for the methods and resources specified. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmLatency">alarmLatency</a></code> | Creates an alarm that monitors the time between when API Gateway receives a request from a client and when it returns a response to the client. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.applyRecommendedAlarms">applyRecommendedAlarms</a></code> | Creates the recommended alarms for the ApiGateway api. |
+
+---
+
+##### `toString` <a name="toString" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.applyRemovalPolicy"></a>
+
+```typescript
+public applyRemovalPolicy(policy: RemovalPolicy): void
+```
+
+Apply the given removal policy to this resource.
+
+The Removal Policy controls what happens to this resource when it stops
+being managed by CloudFormation, either because you've removed it from the
+CDK application or because you've made a change that requires the resource
+to be replaced.
+
+The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
+account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
+
+###### `policy`<sup>Required</sup> <a name="policy" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.applyRemovalPolicy.parameter.policy"></a>
+
+- *Type:* aws-cdk-lib.RemovalPolicy
+
+---
+
+##### `addApiKey` <a name="addApiKey" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addApiKey"></a>
+
+```typescript
+public addApiKey(id: string, options?: ApiKeyOptions): IApiKey
+```
+
+Add an ApiKey to the deploymentStage.
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addApiKey.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `options`<sup>Optional</sup> <a name="options" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addApiKey.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.aws_apigateway.ApiKeyOptions
+
+---
+
+##### `addDomainName` <a name="addDomainName" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addDomainName"></a>
+
+```typescript
+public addDomainName(id: string, options: DomainNameOptions): DomainName
+```
+
+Defines an API Gateway domain name and maps it to this API.
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addDomainName.parameter.id"></a>
+
+- *Type:* string
+
+The construct id.
+
+---
+
+###### `options`<sup>Required</sup> <a name="options" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addDomainName.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.aws_apigateway.DomainNameOptions
+
+custom domain options.
+
+---
+
+##### `addGatewayResponse` <a name="addGatewayResponse" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addGatewayResponse"></a>
+
+```typescript
+public addGatewayResponse(id: string, options: GatewayResponseOptions): GatewayResponse
+```
+
+Adds a new gateway response.
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addGatewayResponse.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `options`<sup>Required</sup> <a name="options" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addGatewayResponse.parameter.options"></a>
+
+- *Type:* aws-cdk-lib.aws_apigateway.GatewayResponseOptions
+
+---
+
+##### `addUsagePlan` <a name="addUsagePlan" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addUsagePlan"></a>
+
+```typescript
+public addUsagePlan(id: string, props?: UsagePlanProps): UsagePlan
+```
+
+Adds a usage plan.
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addUsagePlan.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addUsagePlan.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_apigateway.UsagePlanProps
+
+---
+
+##### `arnForExecuteApi` <a name="arnForExecuteApi" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.arnForExecuteApi"></a>
+
+```typescript
+public arnForExecuteApi(method?: string, path?: string, stage?: string): string
+```
+
+Gets the "execute-api" ARN.
+
+###### `method`<sup>Optional</sup> <a name="method" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.arnForExecuteApi.parameter.method"></a>
+
+- *Type:* string
+
+---
+
+###### `path`<sup>Optional</sup> <a name="path" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.arnForExecuteApi.parameter.path"></a>
+
+- *Type:* string
+
+---
+
+###### `stage`<sup>Optional</sup> <a name="stage" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.arnForExecuteApi.parameter.stage"></a>
+
+- *Type:* string
+
+---
+
+##### `metric` <a name="metric" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metric"></a>
+
+```typescript
+public metric(metricName: string, props?: MetricOptions): Metric
+```
+
+Returns the given named metric for this API.
+
+###### `metricName`<sup>Required</sup> <a name="metricName" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metric.parameter.metricName"></a>
+
+- *Type:* string
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metric.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricCacheHitCount` <a name="metricCacheHitCount" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricCacheHitCount"></a>
+
+```typescript
+public metricCacheHitCount(props?: MetricOptions): Metric
+```
+
+Metric for the number of requests served from the API cache in a given period.
+
+Default: sum over 5 minutes
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricCacheHitCount.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricCacheMissCount` <a name="metricCacheMissCount" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricCacheMissCount"></a>
+
+```typescript
+public metricCacheMissCount(props?: MetricOptions): Metric
+```
+
+Metric for the number of requests served from the backend in a given period, when API caching is enabled.
+
+Default: sum over 5 minutes
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricCacheMissCount.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricClientError` <a name="metricClientError" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricClientError"></a>
+
+```typescript
+public metricClientError(props?: MetricOptions): Metric
+```
+
+Metric for the number of client-side errors captured in a given period.
+
+Default: sum over 5 minutes
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricClientError.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricCount` <a name="metricCount" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricCount"></a>
+
+```typescript
+public metricCount(props?: MetricOptions): Metric
+```
+
+Metric for the total number API requests in a given period.
+
+Default: sample count over 5 minutes
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricCount.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricIntegrationLatency` <a name="metricIntegrationLatency" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricIntegrationLatency"></a>
+
+```typescript
+public metricIntegrationLatency(props?: MetricOptions): Metric
+```
+
+Metric for the time between when API Gateway relays a request to the backend and when it receives a response from the backend.
+
+Default: average over 5 minutes.
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricIntegrationLatency.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricLatency` <a name="metricLatency" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricLatency"></a>
+
+```typescript
+public metricLatency(props?: MetricOptions): Metric
+```
+
+The time between when API Gateway receives a request from a client and when it returns a response to the client.
+
+The latency includes the integration latency and other API Gateway overhead.
+
+Default: average over 5 minutes.
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricLatency.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricServerError` <a name="metricServerError" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricServerError"></a>
+
+```typescript
+public metricServerError(props?: MetricOptions): Metric
+```
+
+Metric for the number of server-side errors captured in a given period.
+
+Default: sum over 5 minutes
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.metricServerError.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `urlForPath` <a name="urlForPath" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.urlForPath"></a>
+
+```typescript
+public urlForPath(path?: string): string
+```
+
+Returns the URL for an HTTP path.
+
+Fails if `deploymentStage` is not set either by `deploy` or explicitly.
+
+###### `path`<sup>Optional</sup> <a name="path" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.urlForPath.parameter.path"></a>
+
+- *Type:* string
+
+---
+
+##### `addModel` <a name="addModel" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addModel"></a>
+
+```typescript
+public addModel(id: string, props: ModelOptions): Model
+```
+
+Adds a new model.
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addModel.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addModel.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_apigateway.ModelOptions
+
+---
+
+##### `addRequestValidator` <a name="addRequestValidator" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addRequestValidator"></a>
+
+```typescript
+public addRequestValidator(id: string, props: RequestValidatorOptions): RequestValidator
+```
+
+Adds a new request validator.
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addRequestValidator.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.addRequestValidator.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_apigateway.RequestValidatorOptions
+
+---
+
+##### `alarm4XXError` <a name="alarm4XXError" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarm4XXError"></a>
+
+```typescript
+public alarm4XXError(props?: ApiGateway4XXErrorAlarmConfig): ApiGatewayRestApi4XXErrorAlarm
+```
+
+Creates an alarm that monitors the number of client-side errors captured in a given period.
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarm4XXError.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig">ApiGateway4XXErrorAlarmConfig</a>
+
+---
+
+##### `alarm5XXError` <a name="alarm5XXError" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarm5XXError"></a>
+
+```typescript
+public alarm5XXError(props?: ApiGateway5XXErrorAlarmConfig): ApiGatewayRestApi5XXErrorAlarm
+```
+
+Creates an alarm that monitors the number of server-side errors captured in a given period.
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarm5XXError.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig">ApiGateway5XXErrorAlarmConfig</a>
+
+---
+
+##### `alarmCount` <a name="alarmCount" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmCount"></a>
+
+```typescript
+public alarmCount(props: ApiGatewayCountAlarmConfig): ApiGatewayRestApiCountAlarm
+```
+
+Creates an alarm that monitors the total number API requests in a given period.
+
+###### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmCount.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig">ApiGatewayCountAlarmConfig</a>
+
+---
+
+##### `alarmDetailedCount` <a name="alarmDetailedCount" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmDetailedCount"></a>
+
+```typescript
+public alarmDetailedCount(props: ApiGatewayRestApiDetailedCountAlarmConfig[]): ApiGatewayRestApiDetailedCountAlarm[]
+```
+
+Creates a list of alarms that monitor the total number API requests in a given period for the methods and resources specified.
+
+###### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmDetailedCount.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig">ApiGatewayRestApiDetailedCountAlarmConfig</a>[]
+
+---
+
+##### `alarmDetailedLatency` <a name="alarmDetailedLatency" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmDetailedLatency"></a>
+
+```typescript
+public alarmDetailedLatency(props: ApiGatewayRestApiDetailedLatencyAlarmConfig[]): ApiGatewayRestApiDetailedLatencyAlarm[]
+```
+
+Creates a list of alarms the time between when API Gateway receives a request from a client and when it returns a response to the client for the methods and resources specified.
+
+###### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmDetailedLatency.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig">ApiGatewayRestApiDetailedLatencyAlarmConfig</a>[]
+
+---
+
+##### `alarmLatency` <a name="alarmLatency" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmLatency"></a>
+
+```typescript
+public alarmLatency(props?: ApiGatewayLatencyAlarmConfig): ApiGatewayRestApiLatencyAlarm
+```
+
+Creates an alarm that monitors the time between when API Gateway receives a request from a client and when it returns a response to the client.
+
+###### `props`<sup>Optional</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.alarmLatency.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig">ApiGatewayLatencyAlarmConfig</a>
+
+---
+
+##### `applyRecommendedAlarms` <a name="applyRecommendedAlarms" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.applyRecommendedAlarms"></a>
+
+```typescript
+public applyRecommendedAlarms(props: ApiGatewayRestApiRecommendedAlarmsConfig): ApiGatewayRestApiRecommendedAlarms
+```
+
+Creates the recommended alarms for the ApiGateway api.
+
+> [https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#ApiGateway](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#ApiGateway)
+
+###### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.applyRecommendedAlarms.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig">ApiGatewayRestApiRecommendedAlarmsConfig</a>
+
+---
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isOwnedResource">isOwnedResource</a></code> | Returns true if the construct was created by CDK, and false otherwise. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.fromRestApiAttributes">fromRestApiAttributes</a></code> | Import an existing RestApi that can be configured with additional Methods and Resources. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.fromRestApiId">fromRestApiId</a></code> | Import an existing RestApi. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isRestApi">isRestApi</a></code> | Return whether the given object is a `RestApi`. |
+
+---
+
+##### ~~`isConstruct`~~ <a name="isConstruct" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isConstruct"></a>
+
+```typescript
+import { RestApi } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+RestApi.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+###### `x`<sup>Required</sup> <a name="x" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+##### `isOwnedResource` <a name="isOwnedResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isOwnedResource"></a>
+
+```typescript
+import { RestApi } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+RestApi.isOwnedResource(construct: IConstruct)
+```
+
+Returns true if the construct was created by CDK, and false otherwise.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isOwnedResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `isResource` <a name="isResource" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isResource"></a>
+
+```typescript
+import { RestApi } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+RestApi.isResource(construct: IConstruct)
+```
+
+Check whether the given construct is a Resource.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+##### `fromRestApiAttributes` <a name="fromRestApiAttributes" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.fromRestApiAttributes"></a>
+
+```typescript
+import { RestApi } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+RestApi.fromRestApiAttributes(scope: Construct, id: string, attrs: RestApiAttributes)
+```
+
+Import an existing RestApi that can be configured with additional Methods and Resources.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.fromRestApiAttributes.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.fromRestApiAttributes.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `attrs`<sup>Required</sup> <a name="attrs" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.fromRestApiAttributes.parameter.attrs"></a>
+
+- *Type:* aws-cdk-lib.aws_apigateway.RestApiAttributes
+
+---
+
+##### `fromRestApiId` <a name="fromRestApiId" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.fromRestApiId"></a>
+
+```typescript
+import { RestApi } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+RestApi.fromRestApiId(scope: Construct, id: string, restApiId: string)
+```
+
+Import an existing RestApi.
+
+###### `scope`<sup>Required</sup> <a name="scope" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.fromRestApiId.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+---
+
+###### `id`<sup>Required</sup> <a name="id" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.fromRestApiId.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `restApiId`<sup>Required</sup> <a name="restApiId" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.fromRestApiId.parameter.restApiId"></a>
+
+- *Type:* string
+
+---
+
+##### `isRestApi` <a name="isRestApi" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isRestApi"></a>
+
+```typescript
+import { RestApi } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+RestApi.isRestApi(x: any)
+```
+
+Return whether the given object is a `RestApi`.
+
+###### `x`<sup>Required</sup> <a name="x" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.isRestApi.parameter.x"></a>
+
+- *Type:* any
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.restApiId">restApiId</a></code> | <code>string</code> | The ID of this API Gateway RestApi. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.restApiName">restApiName</a></code> | <code>string</code> | A human friendly name for this Rest API. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.restApiRootResourceId">restApiRootResourceId</a></code> | <code>string</code> | The resource ID of the root resource. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.root">root</a></code> | <code>aws-cdk-lib.aws_apigateway.IResource</code> | Represents the root resource of this API endpoint ('/'). |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.url">url</a></code> | <code>string</code> | The deployed root URL of this REST API. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.domainName">domainName</a></code> | <code>aws-cdk-lib.aws_apigateway.DomainName</code> | The first domain name mapped to this API, if defined through the `domainName` configuration prop, or added via `addDomainName`. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.latestDeployment">latestDeployment</a></code> | <code>aws-cdk-lib.aws_apigateway.Deployment</code> | API Gateway deployment that represents the latest changes of the API. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.deploymentStage">deploymentStage</a></code> | <code>aws-cdk-lib.aws_apigateway.Stage</code> | API Gateway stage that points to the latest deployment (if defined). |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.methods">methods</a></code> | <code>aws-cdk-lib.aws_apigateway.Method[]</code> | The list of methods bound to this RestApi. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `env`<sup>Required</sup> <a name="env" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.env"></a>
+
+```typescript
+public readonly env: ResourceEnvironment;
+```
+
+- *Type:* aws-cdk-lib.ResourceEnvironment
+
+The environment this resource belongs to.
+
+For resources that are created and managed by the CDK
+(generally, those created by creating new class instances like Role, Bucket, etc.),
+this is always the same as the environment of the stack they belong to;
+however, for imported resources
+(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
+that might be different than the stack they were imported into.
+
+---
+
+##### `stack`<sup>Required</sup> <a name="stack" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* aws-cdk-lib.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### `restApiId`<sup>Required</sup> <a name="restApiId" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.restApiId"></a>
+
+```typescript
+public readonly restApiId: string;
+```
+
+- *Type:* string
+
+The ID of this API Gateway RestApi.
+
+---
+
+##### `restApiName`<sup>Required</sup> <a name="restApiName" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.restApiName"></a>
+
+```typescript
+public readonly restApiName: string;
+```
+
+- *Type:* string
+
+A human friendly name for this Rest API.
+
+Note that this is different from `restApiId`.
+
+---
+
+##### `restApiRootResourceId`<sup>Required</sup> <a name="restApiRootResourceId" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.restApiRootResourceId"></a>
+
+```typescript
+public readonly restApiRootResourceId: string;
+```
+
+- *Type:* string
+
+The resource ID of the root resource.
+
+---
+
+##### `root`<sup>Required</sup> <a name="root" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.root"></a>
+
+```typescript
+public readonly root: IResource;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.IResource
+
+Represents the root resource of this API endpoint ('/').
+
+Resources and Methods are added to this resource.
+
+---
+
+##### `url`<sup>Required</sup> <a name="url" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.url"></a>
+
+```typescript
+public readonly url: string;
+```
+
+- *Type:* string
+
+The deployed root URL of this REST API.
+
+---
+
+##### `domainName`<sup>Optional</sup> <a name="domainName" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.domainName"></a>
+
+```typescript
+public readonly domainName: DomainName;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.DomainName
+
+The first domain name mapped to this API, if defined through the `domainName` configuration prop, or added via `addDomainName`.
+
+---
+
+##### `latestDeployment`<sup>Optional</sup> <a name="latestDeployment" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.latestDeployment"></a>
+
+```typescript
+public readonly latestDeployment: Deployment;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.Deployment
+
+API Gateway deployment that represents the latest changes of the API.
+
+This resource will be automatically updated every time the REST API model changes.
+This will be undefined if `deploy` is false.
+
+---
+
+##### `deploymentStage`<sup>Required</sup> <a name="deploymentStage" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.deploymentStage"></a>
+
+```typescript
+public readonly deploymentStage: Stage;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.Stage
+
+API Gateway stage that points to the latest deployment (if defined).
+
+If `deploy` is disabled, you will need to explicitly assign this value in order to
+set up integrations.
+
+---
+
+##### `methods`<sup>Required</sup> <a name="methods" id="@renovosolutions/cdk-library-cloudwatch-alarms.RestApi.property.methods"></a>
+
+```typescript
+public readonly methods: Method[];
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.Method[]
+
+The list of methods bound to this RestApi.
+
+---
+
+
 ### S3Bucket4xxErrorsAlarm <a name="S3Bucket4xxErrorsAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.S3Bucket4xxErrorsAlarm"></a>
 
 An alarm that monitors the 4xx errors for an S3 bucket.
@@ -20732,6 +24042,2791 @@ public readonly treatMissingData: TreatMissingData;
 - *Default:* TreatMissingData.MISSING
 
 How to handle missing data for this alarm.
+
+---
+
+### ApiGateway4XXErrorAlarmConfig <a name="ApiGateway4XXErrorAlarmConfig" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig"></a>
+
+Configuration for the 4XXError alarm.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.Initializer"></a>
+
+```typescript
+import { ApiGateway4XXErrorAlarmConfig } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGateway4XXErrorAlarmConfig: ApiGateway4XXErrorAlarmConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.threshold">threshold</a></code> | <code>number</code> | The percentage (0-1) value against which the specified statistic is compared. |
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect high rates of client-side errors for the API Gateway requests.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - 4XXError'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+##### `threshold`<sup>Optional</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+- *Default:* 0.05
+
+The percentage (0-1) value against which the specified statistic is compared.
+
+The suggested threshold detects when more than 5% of total requests are getting 4XX errors.
+However, you can tune the threshold to suit the traffic of the requests as well as acceptable
+error rates. You can also analyze historical data to determine the acceptable error rate for
+the application workload and then tune the threshold accordingly. Frequently occurring 4XX
+errors need to be alarmed on. However, setting a very low value for the threshold can cause
+the alarm to be too sensitive.
+
+---
+
+### ApiGateway5XXErrorAlarmConfig <a name="ApiGateway5XXErrorAlarmConfig" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig"></a>
+
+Configuration for the 5XXError alarm.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.Initializer"></a>
+
+```typescript
+import { ApiGateway5XXErrorAlarmConfig } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGateway5XXErrorAlarmConfig: ApiGateway5XXErrorAlarmConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.threshold">threshold</a></code> | <code>number</code> | The percentage (0-1) value against which the specified statistic is compared. |
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect high rates of server-side errors for the API Gateway requests.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - 5XXError'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 3
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 3
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+##### `threshold`<sup>Optional</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+- *Default:* 0.05
+
+The percentage (0-1) value against which the specified statistic is compared.
+
+The suggested threshold detects when more than 5% of total requests are getting 5XX errors.
+However, you can tune the threshold to suit the traffic of the requests as well as acceptable
+error rates. you can also analyze historical data to determine the acceptable error rate for
+the application workload and then tune the threshold accordingly. Frequently occurring 5XX
+errors need to be alarmed on. However, setting a very low value for the threshold can cause
+the alarm to be too sensitive.
+
+---
+
+### ApiGatewayAlarmBaseConfig <a name="ApiGatewayAlarmBaseConfig" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig"></a>
+
+The common optional configuration for the alarms.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig.Initializer"></a>
+
+```typescript
+import { ApiGatewayAlarmBaseConfig } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayAlarmBaseConfig: ApiGatewayAlarmBaseConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayAlarmBaseConfig.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+### ApiGatewayCountAlarmConfig <a name="ApiGatewayCountAlarmConfig" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig"></a>
+
+Configuration for the Count alarm.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.Initializer"></a>
+
+```typescript
+import { ApiGatewayCountAlarmConfig } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayCountAlarmConfig: ApiGatewayCountAlarmConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.threshold">threshold</a></code> | <code>number</code> | The value against which the specified statistic is compared. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `threshold`<sup>Required</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+
+The value against which the specified statistic is compared.
+
+Set the threshold based on historical data analysis to determine what the expected
+baseline request count for your API is. Setting the threshold at a very high value
+might cause the alarm to be too sensitive at periods of normal and expected low traffic.
+Conversely, setting it at a very low value might cause the alarm to miss anomalous
+smaller drops in traffic volume.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect high rates of client-side errors for the API Gateway requests.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - Count'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 10
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 10
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+### ApiGatewayDetailedAlarmConfig <a name="ApiGatewayDetailedAlarmConfig" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayDetailedAlarmConfig"></a>
+
+The common properties for the ApiGateway alarms when monitoring resource and method dimensions.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayDetailedAlarmConfig.Initializer"></a>
+
+```typescript
+import { ApiGatewayDetailedAlarmConfig } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayDetailedAlarmConfig: ApiGatewayDetailedAlarmConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayDetailedAlarmConfig.property.alias">alias</a></code> | <code>string</code> | The alias of the resource to monitor, used as a discriminator in the alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayDetailedAlarmConfig.property.method">method</a></code> | <code>string</code> | The method to monitor. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayDetailedAlarmConfig.property.resource">resource</a></code> | <code>string</code> | The resource to monitor. |
+
+---
+
+##### `alias`<sup>Required</sup> <a name="alias" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayDetailedAlarmConfig.property.alias"></a>
+
+```typescript
+public readonly alias: string;
+```
+
+- *Type:* string
+
+The alias of the resource to monitor, used as a discriminator in the alarm name.
+
+---
+
+##### `method`<sup>Required</sup> <a name="method" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayDetailedAlarmConfig.property.method"></a>
+
+```typescript
+public readonly method: string;
+```
+
+- *Type:* string
+
+The method to monitor.
+
+---
+
+##### `resource`<sup>Required</sup> <a name="resource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayDetailedAlarmConfig.property.resource"></a>
+
+```typescript
+public readonly resource: string;
+```
+
+- *Type:* string
+
+The resource to monitor.
+
+---
+
+### ApiGatewayLatencyAlarmConfig <a name="ApiGatewayLatencyAlarmConfig" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig"></a>
+
+Configuration for the Latency alarm.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.Initializer"></a>
+
+```typescript
+import { ApiGatewayLatencyAlarmConfig } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayLatencyAlarmConfig: ApiGatewayLatencyAlarmConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.threshold">threshold</a></code> | <code>number</code> | The value in milliseconds against which the specified statistic is compared. |
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect when the API Gateway requests in a stage have high latency.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - Latency'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+##### `threshold`<sup>Optional</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+- *Default:* 2500
+
+The value in milliseconds against which the specified statistic is compared.
+
+The suggested threshold value does not work for all API workloads. However, you can
+use it as a starting point for the threshold. You can then choose different threshold
+values based on the workload and acceptable latency, performance, and SLA requirements
+for the API. If it is acceptable for the API to have a higher latency in general, you
+can set a higher threshold value to make the alarm less sensitive. However, if the API
+is expected to provide near real-time responses, set a lower threshold value. You can
+also analyze historical data to determine what the expected baseline latency is for the
+application workload and then tune the threshold value accordingly.
+
+---
+
+### ApiGatewayRestApi4XXErrorAlarmProps <a name="ApiGatewayRestApi4XXErrorAlarmProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps"></a>
+
+The properties for the ApiGatewayRestApi4XXErrorAlarm construct.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApi4XXErrorAlarmProps } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayRestApi4XXErrorAlarmProps: ApiGatewayRestApi4XXErrorAlarmProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.RestApi</code> | The ApiGateway api to monitor. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.threshold">threshold</a></code> | <code>number</code> | The percentage (0-1) value against which the specified statistic is compared. |
+
+---
+
+##### `api`<sup>Required</sup> <a name="api" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.api"></a>
+
+```typescript
+public readonly api: RestApi;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.RestApi
+
+The ApiGateway api to monitor.
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect high rates of client-side errors for the API Gateway requests.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - 4XXError'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+##### `threshold`<sup>Optional</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi4XXErrorAlarmProps.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+- *Default:* 0.05
+
+The percentage (0-1) value against which the specified statistic is compared.
+
+The suggested threshold detects when more than 5% of total requests are getting 4XX errors.
+However, you can tune the threshold to suit the traffic of the requests as well as acceptable
+error rates. You can also analyze historical data to determine the acceptable error rate for
+the application workload and then tune the threshold accordingly. Frequently occurring 4XX
+errors need to be alarmed on. However, setting a very low value for the threshold can cause
+the alarm to be too sensitive.
+
+---
+
+### ApiGatewayRestApi5XXErrorAlarmProps <a name="ApiGatewayRestApi5XXErrorAlarmProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps"></a>
+
+The properties for the ApiGatewayRestApi5XXErrorAlarm construct.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApi5XXErrorAlarmProps } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayRestApi5XXErrorAlarmProps: ApiGatewayRestApi5XXErrorAlarmProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.RestApi</code> | The ApiGateway api to monitor. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.threshold">threshold</a></code> | <code>number</code> | The percentage (0-1) value against which the specified statistic is compared. |
+
+---
+
+##### `api`<sup>Required</sup> <a name="api" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.api"></a>
+
+```typescript
+public readonly api: RestApi;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.RestApi
+
+The ApiGateway api to monitor.
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect high rates of server-side errors for the API Gateway requests.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - 5XXError'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 3
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 3
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+##### `threshold`<sup>Optional</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApi5XXErrorAlarmProps.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+- *Default:* 0.05
+
+The percentage (0-1) value against which the specified statistic is compared.
+
+The suggested threshold detects when more than 5% of total requests are getting 5XX errors.
+However, you can tune the threshold to suit the traffic of the requests as well as acceptable
+error rates. you can also analyze historical data to determine the acceptable error rate for
+the application workload and then tune the threshold accordingly. Frequently occurring 5XX
+errors need to be alarmed on. However, setting a very low value for the threshold can cause
+the alarm to be too sensitive.
+
+---
+
+### ApiGatewayRestApiAlarmProps <a name="ApiGatewayRestApiAlarmProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiAlarmProps"></a>
+
+The common properties for the ApiGateway RestApi alarms.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiAlarmProps.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiAlarmProps } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayRestApiAlarmProps: ApiGatewayRestApiAlarmProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiAlarmProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.RestApi</code> | The ApiGateway api to monitor. |
+
+---
+
+##### `api`<sup>Required</sup> <a name="api" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiAlarmProps.property.api"></a>
+
+```typescript
+public readonly api: RestApi;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.RestApi
+
+The ApiGateway api to monitor.
+
+---
+
+### ApiGatewayRestApiCountAlarmProps <a name="ApiGatewayRestApiCountAlarmProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps"></a>
+
+The properties for the ApiGatewayRestApiCountAlarm construct.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiCountAlarmProps } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayRestApiCountAlarmProps: ApiGatewayRestApiCountAlarmProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.RestApi</code> | The ApiGateway api to monitor. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.threshold">threshold</a></code> | <code>number</code> | The value against which the specified statistic is compared. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+
+---
+
+##### `api`<sup>Required</sup> <a name="api" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.api"></a>
+
+```typescript
+public readonly api: RestApi;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.RestApi
+
+The ApiGateway api to monitor.
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `threshold`<sup>Required</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+
+The value against which the specified statistic is compared.
+
+Set the threshold based on historical data analysis to determine what the expected
+baseline request count for your API is. Setting the threshold at a very high value
+might cause the alarm to be too sensitive at periods of normal and expected low traffic.
+Conversely, setting it at a very low value might cause the alarm to miss anomalous
+smaller drops in traffic volume.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect high rates of client-side errors for the API Gateway requests.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - Count'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 10
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiCountAlarmProps.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 10
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+### ApiGatewayRestApiDetailedCountAlarmConfig <a name="ApiGatewayRestApiDetailedCountAlarmConfig" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig"></a>
+
+Configuration for the Count alarm when monitoring resource and method dimensions.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedCountAlarmConfig } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayRestApiDetailedCountAlarmConfig: ApiGatewayRestApiDetailedCountAlarmConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.threshold">threshold</a></code> | <code>number</code> | The value against which the specified statistic is compared. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.alias">alias</a></code> | <code>string</code> | The alias of the resource to monitor, used as a discriminator in the alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.method">method</a></code> | <code>string</code> | The method to monitor. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.resource">resource</a></code> | <code>string</code> | The resource to monitor. |
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `threshold`<sup>Required</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+
+The value against which the specified statistic is compared.
+
+Set the threshold based on historical data analysis to determine what the expected
+baseline request count for your API is. Setting the threshold at a very high value
+might cause the alarm to be too sensitive at periods of normal and expected low traffic.
+Conversely, setting it at a very low value might cause the alarm to miss anomalous
+smaller drops in traffic volume.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect high rates of client-side errors for the API Gateway requests.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - Count'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 10
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 10
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+##### `alias`<sup>Required</sup> <a name="alias" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.alias"></a>
+
+```typescript
+public readonly alias: string;
+```
+
+- *Type:* string
+
+The alias of the resource to monitor, used as a discriminator in the alarm name.
+
+---
+
+##### `method`<sup>Required</sup> <a name="method" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.method"></a>
+
+```typescript
+public readonly method: string;
+```
+
+- *Type:* string
+
+The method to monitor.
+
+---
+
+##### `resource`<sup>Required</sup> <a name="resource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig.property.resource"></a>
+
+```typescript
+public readonly resource: string;
+```
+
+- *Type:* string
+
+The resource to monitor.
+
+---
+
+### ApiGatewayRestApiDetailedCountAlarmProps <a name="ApiGatewayRestApiDetailedCountAlarmProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps"></a>
+
+The properties for the ApiGatewayRestApiDetailedCountAlarm construct.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedCountAlarmProps } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayRestApiDetailedCountAlarmProps: ApiGatewayRestApiDetailedCountAlarmProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.RestApi</code> | The ApiGateway api to monitor. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.threshold">threshold</a></code> | <code>number</code> | The value against which the specified statistic is compared. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.alias">alias</a></code> | <code>string</code> | The alias of the resource to monitor, used as a discriminator in the alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.method">method</a></code> | <code>string</code> | The method to monitor. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.resource">resource</a></code> | <code>string</code> | The resource to monitor. |
+
+---
+
+##### `api`<sup>Required</sup> <a name="api" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.api"></a>
+
+```typescript
+public readonly api: RestApi;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.RestApi
+
+The ApiGateway api to monitor.
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `threshold`<sup>Required</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+
+The value against which the specified statistic is compared.
+
+Set the threshold based on historical data analysis to determine what the expected
+baseline request count for your API is. Setting the threshold at a very high value
+might cause the alarm to be too sensitive at periods of normal and expected low traffic.
+Conversely, setting it at a very low value might cause the alarm to miss anomalous
+smaller drops in traffic volume.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect high rates of client-side errors for the API Gateway requests.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - Count'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 10
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 10
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+##### `alias`<sup>Required</sup> <a name="alias" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.alias"></a>
+
+```typescript
+public readonly alias: string;
+```
+
+- *Type:* string
+
+The alias of the resource to monitor, used as a discriminator in the alarm name.
+
+---
+
+##### `method`<sup>Required</sup> <a name="method" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.method"></a>
+
+```typescript
+public readonly method: string;
+```
+
+- *Type:* string
+
+The method to monitor.
+
+---
+
+##### `resource`<sup>Required</sup> <a name="resource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmProps.property.resource"></a>
+
+```typescript
+public readonly resource: string;
+```
+
+- *Type:* string
+
+The resource to monitor.
+
+---
+
+### ApiGatewayRestApiDetailedLatencyAlarmConfig <a name="ApiGatewayRestApiDetailedLatencyAlarmConfig" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig"></a>
+
+Configuration for the Latency alarm when monitoring resource and method dimensions.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedLatencyAlarmConfig } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayRestApiDetailedLatencyAlarmConfig: ApiGatewayRestApiDetailedLatencyAlarmConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.threshold">threshold</a></code> | <code>number</code> | The value in milliseconds against which the specified statistic is compared. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.alias">alias</a></code> | <code>string</code> | The alias of the resource to monitor, used as a discriminator in the alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.method">method</a></code> | <code>string</code> | The method to monitor. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.resource">resource</a></code> | <code>string</code> | The resource to monitor. |
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect when the API Gateway requests in a stage have high latency.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - Latency'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+##### `threshold`<sup>Optional</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+- *Default:* 2500
+
+The value in milliseconds against which the specified statistic is compared.
+
+The suggested threshold value does not work for all API workloads. However, you can
+use it as a starting point for the threshold. You can then choose different threshold
+values based on the workload and acceptable latency, performance, and SLA requirements
+for the API. If it is acceptable for the API to have a higher latency in general, you
+can set a higher threshold value to make the alarm less sensitive. However, if the API
+is expected to provide near real-time responses, set a lower threshold value. You can
+also analyze historical data to determine what the expected baseline latency is for the
+application workload and then tune the threshold value accordingly.
+
+---
+
+##### `alias`<sup>Required</sup> <a name="alias" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.alias"></a>
+
+```typescript
+public readonly alias: string;
+```
+
+- *Type:* string
+
+The alias of the resource to monitor, used as a discriminator in the alarm name.
+
+---
+
+##### `method`<sup>Required</sup> <a name="method" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.method"></a>
+
+```typescript
+public readonly method: string;
+```
+
+- *Type:* string
+
+The method to monitor.
+
+---
+
+##### `resource`<sup>Required</sup> <a name="resource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig.property.resource"></a>
+
+```typescript
+public readonly resource: string;
+```
+
+- *Type:* string
+
+The resource to monitor.
+
+---
+
+### ApiGatewayRestApiDetailedLatencyAlarmProps <a name="ApiGatewayRestApiDetailedLatencyAlarmProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps"></a>
+
+The properties for the ApiGatewayRestApiDetailedLatencyAlarm construct.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiDetailedLatencyAlarmProps } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayRestApiDetailedLatencyAlarmProps: ApiGatewayRestApiDetailedLatencyAlarmProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.RestApi</code> | The ApiGateway api to monitor. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.threshold">threshold</a></code> | <code>number</code> | The value in milliseconds against which the specified statistic is compared. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.alias">alias</a></code> | <code>string</code> | The alias of the resource to monitor, used as a discriminator in the alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.method">method</a></code> | <code>string</code> | The method to monitor. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.resource">resource</a></code> | <code>string</code> | The resource to monitor. |
+
+---
+
+##### `api`<sup>Required</sup> <a name="api" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.api"></a>
+
+```typescript
+public readonly api: RestApi;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.RestApi
+
+The ApiGateway api to monitor.
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect when the API Gateway requests in a stage have high latency.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - Latency'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+##### `threshold`<sup>Optional</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+- *Default:* 2500
+
+The value in milliseconds against which the specified statistic is compared.
+
+The suggested threshold value does not work for all API workloads. However, you can
+use it as a starting point for the threshold. You can then choose different threshold
+values based on the workload and acceptable latency, performance, and SLA requirements
+for the API. If it is acceptable for the API to have a higher latency in general, you
+can set a higher threshold value to make the alarm less sensitive. However, if the API
+is expected to provide near real-time responses, set a lower threshold value. You can
+also analyze historical data to determine what the expected baseline latency is for the
+application workload and then tune the threshold value accordingly.
+
+---
+
+##### `alias`<sup>Required</sup> <a name="alias" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.alias"></a>
+
+```typescript
+public readonly alias: string;
+```
+
+- *Type:* string
+
+The alias of the resource to monitor, used as a discriminator in the alarm name.
+
+---
+
+##### `method`<sup>Required</sup> <a name="method" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.method"></a>
+
+```typescript
+public readonly method: string;
+```
+
+- *Type:* string
+
+The method to monitor.
+
+---
+
+##### `resource`<sup>Required</sup> <a name="resource" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmProps.property.resource"></a>
+
+```typescript
+public readonly resource: string;
+```
+
+- *Type:* string
+
+The resource to monitor.
+
+---
+
+### ApiGatewayRestApiLatencyAlarmProps <a name="ApiGatewayRestApiLatencyAlarmProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps"></a>
+
+The properties for the ApiGatewayRestApiLatencyAlarm construct.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiLatencyAlarmProps } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayRestApiLatencyAlarmProps: ApiGatewayRestApiLatencyAlarmProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.RestApi</code> | The ApiGateway api to monitor. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.alarmAction">alarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.insufficientDataAction">insufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.okAction">okAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the specified statistic is applied. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | The description of the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.alarmName">alarmName</a></code> | <code>string</code> | The alarm name. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | The number of data points that must be breaching to trigger the alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | The number of periods over which data is compared to the specified threshold. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.threshold">threshold</a></code> | <code>number</code> | The value in milliseconds against which the specified statistic is compared. |
+
+---
+
+##### `api`<sup>Required</sup> <a name="api" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.api"></a>
+
+```typescript
+public readonly api: RestApi;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.RestApi
+
+The ApiGateway api to monitor.
+
+---
+
+##### `alarmAction`<sup>Optional</sup> <a name="alarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.alarmAction"></a>
+
+```typescript
+public readonly alarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm is triggered.
+
+---
+
+##### `insufficientDataAction`<sup>Optional</sup> <a name="insufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.insufficientDataAction"></a>
+
+```typescript
+public readonly insufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm has insufficient data.
+
+---
+
+##### `okAction`<sup>Optional</sup> <a name="okAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.okAction"></a>
+
+```typescript
+public readonly okAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The action to take when an alarm enters the ok state.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Duration.minutes(1)
+
+The period over which the specified statistic is applied.
+
+---
+
+##### `alarmDescription`<sup>Optional</sup> <a name="alarmDescription" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.alarmDescription"></a>
+
+```typescript
+public readonly alarmDescription: string;
+```
+
+- *Type:* string
+- *Default:* This alarm can detect when the API Gateway requests in a stage have high latency.
+
+The description of the alarm.
+
+---
+
+##### `alarmName`<sup>Optional</sup> <a name="alarmName" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.alarmName"></a>
+
+```typescript
+public readonly alarmName: string;
+```
+
+- *Type:* string
+- *Default:* apiName + ' - Latency'
+
+The alarm name.
+
+---
+
+##### `datapointsToAlarm`<sup>Optional</sup> <a name="datapointsToAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of data points that must be breaching to trigger the alarm.
+
+---
+
+##### `evaluationPeriods`<sup>Optional</sup> <a name="evaluationPeriods" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+- *Default:* 5
+
+The number of periods over which data is compared to the specified threshold.
+
+---
+
+##### `threshold`<sup>Optional</sup> <a name="threshold" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiLatencyAlarmProps.property.threshold"></a>
+
+```typescript
+public readonly threshold: number;
+```
+
+- *Type:* number
+- *Default:* 2500
+
+The value in milliseconds against which the specified statistic is compared.
+
+The suggested threshold value does not work for all API workloads. However, you can
+use it as a starting point for the threshold. You can then choose different threshold
+values based on the workload and acceptable latency, performance, and SLA requirements
+for the API. If it is acceptable for the API to have a higher latency in general, you
+can set a higher threshold value to make the alarm less sensitive. However, if the API
+is expected to provide near real-time responses, set a lower threshold value. You can
+also analyze historical data to determine what the expected baseline latency is for the
+application workload and then tune the threshold value accordingly.
+
+---
+
+### ApiGatewayRestApiRecommendedAlarmsConfig <a name="ApiGatewayRestApiRecommendedAlarmsConfig" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig"></a>
+
+Configurations for the recommended alarms for an ApiGateway RestApi.
+
+Default actions are overridden by the actions specified in the
+individual alarm configurations.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiRecommendedAlarmsConfig } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayRestApiRecommendedAlarmsConfig: ApiGatewayRestApiRecommendedAlarmsConfig = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.configCountAlarm">configCountAlarm</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig">ApiGatewayCountAlarmConfig</a></code> | The configuration for the Count alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.config4XXErrorAlarm">config4XXErrorAlarm</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig">ApiGateway4XXErrorAlarmConfig</a></code> | The configuration for the 4XXError alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.config5XXErrorAlarm">config5XXErrorAlarm</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig">ApiGateway5XXErrorAlarmConfig</a></code> | The configuration for the 5XXError alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.configDetailedCountAlarmList">configDetailedCountAlarmList</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig">ApiGatewayRestApiDetailedCountAlarmConfig</a>[]</code> | The configuration list for the detailed Count alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.configDetailedLatencyAlarmList">configDetailedLatencyAlarmList</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig">ApiGatewayRestApiDetailedLatencyAlarmConfig</a>[]</code> | The configuration list for the detailed Latency alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.configLatencyAlarm">configLatencyAlarm</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig">ApiGatewayLatencyAlarmConfig</a></code> | The configuration for the Latency alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.defaultAlarmAction">defaultAlarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.defaultInsufficientDataAction">defaultInsufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.defaultOkAction">defaultOkAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.excludeAlarms">excludeAlarms</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics">ApiGatewayRecommendedAlarmsMetrics</a>[]</code> | Alarm metrics to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.excludeResources">excludeResources</a></code> | <code>string[]</code> | The resources to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+
+---
+
+##### `configCountAlarm`<sup>Required</sup> <a name="configCountAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.configCountAlarm"></a>
+
+```typescript
+public readonly configCountAlarm: ApiGatewayCountAlarmConfig;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig">ApiGatewayCountAlarmConfig</a>
+
+The configuration for the Count alarm.
+
+---
+
+##### `config4XXErrorAlarm`<sup>Optional</sup> <a name="config4XXErrorAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.config4XXErrorAlarm"></a>
+
+```typescript
+public readonly config4XXErrorAlarm: ApiGateway4XXErrorAlarmConfig;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig">ApiGateway4XXErrorAlarmConfig</a>
+
+The configuration for the 4XXError alarm.
+
+---
+
+##### `config5XXErrorAlarm`<sup>Optional</sup> <a name="config5XXErrorAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.config5XXErrorAlarm"></a>
+
+```typescript
+public readonly config5XXErrorAlarm: ApiGateway5XXErrorAlarmConfig;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig">ApiGateway5XXErrorAlarmConfig</a>
+
+The configuration for the 5XXError alarm.
+
+---
+
+##### `configDetailedCountAlarmList`<sup>Optional</sup> <a name="configDetailedCountAlarmList" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.configDetailedCountAlarmList"></a>
+
+```typescript
+public readonly configDetailedCountAlarmList: ApiGatewayRestApiDetailedCountAlarmConfig[];
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig">ApiGatewayRestApiDetailedCountAlarmConfig</a>[]
+
+The configuration list for the detailed Count alarm.
+
+---
+
+##### `configDetailedLatencyAlarmList`<sup>Optional</sup> <a name="configDetailedLatencyAlarmList" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.configDetailedLatencyAlarmList"></a>
+
+```typescript
+public readonly configDetailedLatencyAlarmList: ApiGatewayRestApiDetailedLatencyAlarmConfig[];
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig">ApiGatewayRestApiDetailedLatencyAlarmConfig</a>[]
+
+The configuration list for the detailed Latency alarm.
+
+---
+
+##### `configLatencyAlarm`<sup>Optional</sup> <a name="configLatencyAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.configLatencyAlarm"></a>
+
+```typescript
+public readonly configLatencyAlarm: ApiGatewayLatencyAlarmConfig;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig">ApiGatewayLatencyAlarmConfig</a>
+
+The configuration for the Latency alarm.
+
+---
+
+##### `defaultAlarmAction`<sup>Optional</sup> <a name="defaultAlarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.defaultAlarmAction"></a>
+
+```typescript
+public readonly defaultAlarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The default action to take when an alarm is triggered.
+
+---
+
+##### `defaultInsufficientDataAction`<sup>Optional</sup> <a name="defaultInsufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.defaultInsufficientDataAction"></a>
+
+```typescript
+public readonly defaultInsufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The default action to take when an alarm has insufficient data.
+
+---
+
+##### `defaultOkAction`<sup>Optional</sup> <a name="defaultOkAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.defaultOkAction"></a>
+
+```typescript
+public readonly defaultOkAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The default action to take when an alarm enters the ok state.
+
+---
+
+##### `excludeAlarms`<sup>Optional</sup> <a name="excludeAlarms" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.excludeAlarms"></a>
+
+```typescript
+public readonly excludeAlarms: ApiGatewayRecommendedAlarmsMetrics[];
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics">ApiGatewayRecommendedAlarmsMetrics</a>[]
+- *Default:* None
+
+Alarm metrics to exclude from the recommended alarms.
+
+---
+
+##### `excludeResources`<sup>Optional</sup> <a name="excludeResources" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.excludeResources"></a>
+
+```typescript
+public readonly excludeResources: string[];
+```
+
+- *Type:* string[]
+
+The resources to exclude from the recommended alarms.
+
+Use a resources id to exclude a specific resource.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+### ApiGatewayRestApiRecommendedAlarmsProps <a name="ApiGatewayRestApiRecommendedAlarmsProps" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps"></a>
+
+Properties for the ApiGatewayRestApiRecommendedAlarms construct.
+
+#### Initializer <a name="Initializer" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.Initializer"></a>
+
+```typescript
+import { ApiGatewayRestApiRecommendedAlarmsProps } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+const apiGatewayRestApiRecommendedAlarmsProps: ApiGatewayRestApiRecommendedAlarmsProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.configCountAlarm">configCountAlarm</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig">ApiGatewayCountAlarmConfig</a></code> | The configuration for the Count alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.config4XXErrorAlarm">config4XXErrorAlarm</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig">ApiGateway4XXErrorAlarmConfig</a></code> | The configuration for the 4XXError alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.config5XXErrorAlarm">config5XXErrorAlarm</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig">ApiGateway5XXErrorAlarmConfig</a></code> | The configuration for the 5XXError alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.configDetailedCountAlarmList">configDetailedCountAlarmList</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig">ApiGatewayRestApiDetailedCountAlarmConfig</a>[]</code> | The configuration list for the detailed Count alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.configDetailedLatencyAlarmList">configDetailedLatencyAlarmList</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig">ApiGatewayRestApiDetailedLatencyAlarmConfig</a>[]</code> | The configuration list for the detailed Latency alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.configLatencyAlarm">configLatencyAlarm</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig">ApiGatewayLatencyAlarmConfig</a></code> | The configuration for the Latency alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.defaultAlarmAction">defaultAlarmAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm is triggered. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.defaultInsufficientDataAction">defaultInsufficientDataAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm has insufficient data. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.defaultOkAction">defaultOkAction</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarmAction</code> | The default action to take when an alarm enters the ok state. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.excludeAlarms">excludeAlarms</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics">ApiGatewayRecommendedAlarmsMetrics</a>[]</code> | Alarm metrics to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.excludeResources">excludeResources</a></code> | <code>string[]</code> | The resources to exclude from the recommended alarms. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.treatMissingData">treatMissingData</a></code> | <code>aws-cdk-lib.aws_cloudwatch.TreatMissingData</code> | How to handle missing data for this alarm. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.RestApi</code> | The ApiGateway api to monitor. |
+
+---
+
+##### `configCountAlarm`<sup>Required</sup> <a name="configCountAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.configCountAlarm"></a>
+
+```typescript
+public readonly configCountAlarm: ApiGatewayCountAlarmConfig;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayCountAlarmConfig">ApiGatewayCountAlarmConfig</a>
+
+The configuration for the Count alarm.
+
+---
+
+##### `config4XXErrorAlarm`<sup>Optional</sup> <a name="config4XXErrorAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.config4XXErrorAlarm"></a>
+
+```typescript
+public readonly config4XXErrorAlarm: ApiGateway4XXErrorAlarmConfig;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway4XXErrorAlarmConfig">ApiGateway4XXErrorAlarmConfig</a>
+
+The configuration for the 4XXError alarm.
+
+---
+
+##### `config5XXErrorAlarm`<sup>Optional</sup> <a name="config5XXErrorAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.config5XXErrorAlarm"></a>
+
+```typescript
+public readonly config5XXErrorAlarm: ApiGateway5XXErrorAlarmConfig;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGateway5XXErrorAlarmConfig">ApiGateway5XXErrorAlarmConfig</a>
+
+The configuration for the 5XXError alarm.
+
+---
+
+##### `configDetailedCountAlarmList`<sup>Optional</sup> <a name="configDetailedCountAlarmList" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.configDetailedCountAlarmList"></a>
+
+```typescript
+public readonly configDetailedCountAlarmList: ApiGatewayRestApiDetailedCountAlarmConfig[];
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedCountAlarmConfig">ApiGatewayRestApiDetailedCountAlarmConfig</a>[]
+
+The configuration list for the detailed Count alarm.
+
+---
+
+##### `configDetailedLatencyAlarmList`<sup>Optional</sup> <a name="configDetailedLatencyAlarmList" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.configDetailedLatencyAlarmList"></a>
+
+```typescript
+public readonly configDetailedLatencyAlarmList: ApiGatewayRestApiDetailedLatencyAlarmConfig[];
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiDetailedLatencyAlarmConfig">ApiGatewayRestApiDetailedLatencyAlarmConfig</a>[]
+
+The configuration list for the detailed Latency alarm.
+
+---
+
+##### `configLatencyAlarm`<sup>Optional</sup> <a name="configLatencyAlarm" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.configLatencyAlarm"></a>
+
+```typescript
+public readonly configLatencyAlarm: ApiGatewayLatencyAlarmConfig;
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayLatencyAlarmConfig">ApiGatewayLatencyAlarmConfig</a>
+
+The configuration for the Latency alarm.
+
+---
+
+##### `defaultAlarmAction`<sup>Optional</sup> <a name="defaultAlarmAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.defaultAlarmAction"></a>
+
+```typescript
+public readonly defaultAlarmAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The default action to take when an alarm is triggered.
+
+---
+
+##### `defaultInsufficientDataAction`<sup>Optional</sup> <a name="defaultInsufficientDataAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.defaultInsufficientDataAction"></a>
+
+```typescript
+public readonly defaultInsufficientDataAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The default action to take when an alarm has insufficient data.
+
+---
+
+##### `defaultOkAction`<sup>Optional</sup> <a name="defaultOkAction" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.defaultOkAction"></a>
+
+```typescript
+public readonly defaultOkAction: IAlarmAction;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarmAction
+- *Default:* None
+
+The default action to take when an alarm enters the ok state.
+
+---
+
+##### `excludeAlarms`<sup>Optional</sup> <a name="excludeAlarms" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.excludeAlarms"></a>
+
+```typescript
+public readonly excludeAlarms: ApiGatewayRecommendedAlarmsMetrics[];
+```
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics">ApiGatewayRecommendedAlarmsMetrics</a>[]
+- *Default:* None
+
+Alarm metrics to exclude from the recommended alarms.
+
+---
+
+##### `excludeResources`<sup>Optional</sup> <a name="excludeResources" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.excludeResources"></a>
+
+```typescript
+public readonly excludeResources: string[];
+```
+
+- *Type:* string[]
+
+The resources to exclude from the recommended alarms.
+
+Use a resources id to exclude a specific resource.
+
+---
+
+##### `treatMissingData`<sup>Optional</sup> <a name="treatMissingData" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.treatMissingData"></a>
+
+```typescript
+public readonly treatMissingData: TreatMissingData;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.TreatMissingData
+- *Default:* TreatMissingData.MISSING
+
+How to handle missing data for this alarm.
+
+---
+
+##### `api`<sup>Required</sup> <a name="api" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsProps.property.api"></a>
+
+```typescript
+public readonly api: RestApi;
+```
+
+- *Type:* aws-cdk-lib.aws_apigateway.RestApi
+
+The ApiGateway api to monitor.
 
 ---
 
@@ -35807,6 +41902,59 @@ The SQS queue for which to create the alarms.
 
 ## Classes <a name="Classes" id="Classes"></a>
 
+### ApiGatewayRecommendedAlarmsAspect <a name="ApiGatewayRecommendedAlarmsAspect" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsAspect"></a>
+
+- *Implements:* aws-cdk-lib.IAspect
+
+Configures the recommended alarms for an ApiGateway api.
+
+> [https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#ApiGateway](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#ApiGateway)
+
+#### Initializers <a name="Initializers" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsAspect.Initializer"></a>
+
+```typescript
+import { ApiGatewayRecommendedAlarmsAspect } from '@renovosolutions/cdk-library-cloudwatch-alarms'
+
+new ApiGatewayRecommendedAlarmsAspect(props: ApiGatewayRestApiRecommendedAlarmsConfig)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsAspect.Initializer.parameter.props">props</a></code> | <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig">ApiGatewayRestApiRecommendedAlarmsConfig</a></code> | *No description.* |
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsAspect.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRestApiRecommendedAlarmsConfig">ApiGatewayRestApiRecommendedAlarmsConfig</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsAspect.visit">visit</a></code> | All aspects can visit an IConstruct. |
+
+---
+
+##### `visit` <a name="visit" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsAspect.visit"></a>
+
+```typescript
+public visit(node: IConstruct): void
+```
+
+All aspects can visit an IConstruct.
+
+###### `node`<sup>Required</sup> <a name="node" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsAspect.visit.parameter.node"></a>
+
+- *Type:* constructs.IConstruct
+
+---
+
+
+
+
 ### EcsRecommendedAlarmsAspect <a name="EcsRecommendedAlarmsAspect" id="@renovosolutions/cdk-library-cloudwatch-alarms.EcsRecommendedAlarmsAspect"></a>
 
 - *Implements:* aws-cdk-lib.IAspect
@@ -36235,6 +42383,52 @@ All aspects can visit an IConstruct.
 
 
 ## Enums <a name="Enums" id="Enums"></a>
+
+### ApiGatewayRecommendedAlarmsMetrics <a name="ApiGatewayRecommendedAlarmsMetrics" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics"></a>
+
+The recommended metrics for ApiGateway alarms.
+
+#### Members <a name="Members" id="Members"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics.ERROR_4XX">ERROR_4XX</a></code> | The number of client-side errors captured in a given period. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics.ERROR_5XX">ERROR_5XX</a></code> | The number of server-side errors captured in a given period. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics.COUNT">COUNT</a></code> | The total number API requests in a given period. |
+| <code><a href="#@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics.LATENCY">LATENCY</a></code> | The time (milliseconds) between when API Gateway receives a request from a client and when it returns a response to the client. |
+
+---
+
+##### `ERROR_4XX` <a name="ERROR_4XX" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics.ERROR_4XX"></a>
+
+The number of client-side errors captured in a given period.
+
+---
+
+
+##### `ERROR_5XX` <a name="ERROR_5XX" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics.ERROR_5XX"></a>
+
+The number of server-side errors captured in a given period.
+
+---
+
+
+##### `COUNT` <a name="COUNT" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics.COUNT"></a>
+
+The total number API requests in a given period.
+
+---
+
+
+##### `LATENCY` <a name="LATENCY" id="@renovosolutions/cdk-library-cloudwatch-alarms.ApiGatewayRecommendedAlarmsMetrics.LATENCY"></a>
+
+The time (milliseconds) between when API Gateway receives a request from a client and when it returns a response to the client.
+
+The latency includes the integration latency
+and other API Gateway overhead.
+
+---
+
 
 ### EcsRecommendedAlarmsMetrics <a name="EcsRecommendedAlarmsMetrics" id="@renovosolutions/cdk-library-cloudwatch-alarms.EcsRecommendedAlarmsMetrics"></a>
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If its not shown it hasn't been worked on.
 | RDS | <b>For database & cluster instances</b><br/><ul><li>[x] CPUUtilization</li><li>[x] DatabaseConnections</li><li>[x] FreeableMemory</li><li>[x] FreeLocalStorage</li><li>[x] FreeStorageSpace</li><li>[x] ReadLatency</li><li>[x] WriteLatency</li><li>[x] DBLoad</li></ul><b>For clusters</b><br/><ul><li>[x] AuroraVolumeBytesLeftTotal</li><li>[x] AuroraBinlogReplicaLag</li></ul> | Some alarms require a `threshold` to be defined. `AuroraVolumeBytesLeftTotal` and `AuroraBinlogReplicaLag` alarms are created only for Aurora MySQL clusters. |
 | ECS | <ul><li>[x] CPUUtilization</li><li>[x] MemoryUtilization</li><li>[x] EphemeralStorageUtilized</li><li>[x] RunningTaskCount</li></ul> | The alarms are applied to `FargateService` constructs only. `EphemeralStorageUtilized` requires a `threshold` to be defined. |
 | EFS | <ul><li>[x] PercentIOLimit</li><li>[x] BurstCreditBalance</li></ul> | The alarms are applied to `FileSystem` constructs. |
+| ApiGateway | <ul><li>[x] 4XXError</li><li>[x] 5XXError</li><li>[x] Count</li><li>[x] Latency</li></ul> | The alarms are applied to `RestApi` constructs only. `Count` requires a `threshold` to be defined. Alarms are automatically created using the `ApiName` and `Stage` dimensions. To create `Count` or `Latency` alarms using the `Resource` and `Method` dimensions, the corresponding properties must be explicitly specified. |
 
 ### Aspects
 

--- a/src/apigateway.ts
+++ b/src/apigateway.ts
@@ -1,0 +1,930 @@
+import {
+  IAspect,
+  aws_apigateway as apigateway,
+  aws_cloudwatch as cloudwatch,
+  Duration,
+} from 'aws-cdk-lib';
+import { Construct, IConstruct } from 'constructs';
+import { AlarmBaseProps, validateTotalAlarmPeriod } from './common';
+
+/**
+ * The recommended metrics for ApiGateway alarms.
+ */
+export enum ApiGatewayRecommendedAlarmsMetrics {
+  /**
+   * The number of client-side errors captured in a given period.
+   */
+  ERROR_4XX = '4XXError',
+  /**
+   * The number of server-side errors captured in a given period.
+   */
+  ERROR_5XX = '5XXError',
+  /**
+   * The total number API requests in a given period.
+   */
+  COUNT = 'Count',
+  /**
+   * The time (milliseconds) between when API Gateway receives a request from a client and
+   * when it returns a response to the client. The latency includes the integration latency
+   * and other API Gateway overhead.
+   */
+  LATENCY = 'Latency',
+}
+
+/**
+ * The common optional configuration for the alarms.
+ */
+export interface ApiGatewayAlarmBaseConfig extends AlarmBaseProps {
+  /**
+   * The period over which the specified statistic is applied.
+   *
+   * @default Duration.minutes(1)
+   */
+  readonly period?: Duration;
+}
+
+/**
+ * The common properties for the ApiGateway alarms when monitoring resource and method dimensions.
+ */
+export interface ApiGatewayDetailedAlarmConfig {
+  /**
+   * The alias of the resource to monitor, used as a discriminator in the alarm name.
+   */
+  readonly alias: string;
+
+  /**
+   * The resource to monitor.
+   */
+  readonly resource: string;
+
+  /**
+   * The method to monitor.
+   */
+  readonly method: string;
+}
+
+/**
+ * The common properties for the ApiGateway RestApi alarms.
+ */
+export interface ApiGatewayRestApiAlarmProps {
+  /**
+   * The ApiGateway api to monitor.
+   */
+  readonly api: apigateway.RestApi;
+}
+
+/**
+ * Configuration for the 4XXError alarm.
+ */
+export interface ApiGateway4XXErrorAlarmConfig extends ApiGatewayAlarmBaseConfig {
+  /**
+   * The percentage (0-1) value against which the specified statistic is compared.
+   * The suggested threshold detects when more than 5% of total requests are getting 4XX errors.
+   * However, you can tune the threshold to suit the traffic of the requests as well as acceptable
+   * error rates. You can also analyze historical data to determine the acceptable error rate for
+   * the application workload and then tune the threshold accordingly. Frequently occurring 4XX
+   * errors need to be alarmed on. However, setting a very low value for the threshold can cause
+   * the alarm to be too sensitive.
+   *
+   * @default 0.05
+   */
+  readonly threshold?: number;
+  /**
+   * The number of periods over which data is compared to the specified threshold.
+   *
+   * @default 5
+   */
+  readonly evaluationPeriods?: number;
+  /**
+   * The number of data points that must be breaching to trigger the alarm.
+   *
+   * @default 5
+   */
+  readonly datapointsToAlarm?: number;
+  /**
+   * The alarm name.
+   *
+   * @default - apiName + ' - 4XXError'
+   */
+  readonly alarmName?: string;
+  /**
+   * The description of the alarm.
+   *
+   * @default - This alarm can detect high rates of client-side errors for the API Gateway requests.
+   */
+  readonly alarmDescription?: string;
+}
+
+/**
+ * The properties for the ApiGatewayRestApi4XXErrorAlarm construct.
+ */
+export interface ApiGatewayRestApi4XXErrorAlarmProps extends ApiGatewayRestApiAlarmProps, ApiGateway4XXErrorAlarmConfig {}
+
+/**
+ * This alarm detects a high rate of client-side errors.
+ *
+ * This can indicate an issue in the authorization or client request parameters. It could also mean that a resource was
+ * removed or a client is requesting one that doesn't exist. Consider enabling CloudWatch Logs and checking for any errors
+ * that may be causing the 4XX errors. Moreover, consider enabling detailed CloudWatch metrics to view this metric per
+ * resource and method and narrow down the source of the errors. Errors could also be caused by exceeding the configured
+ * throttling limit.
+ *
+ * The alarm is triggered when percentage of client-errors exceeds the threshold.
+ */
+export class ApiGatewayRestApi4XXErrorAlarm extends cloudwatch.Alarm {
+  constructor(scope: IConstruct, id: string, props: ApiGatewayRestApi4XXErrorAlarmProps) {
+    const alarmName = props.alarmName ?? `${props.api.restApiName} - ${ApiGatewayRecommendedAlarmsMetrics.ERROR_4XX}`;
+    const period = props.period ?? Duration.minutes(1);
+    const evaluationPeriods = props.evaluationPeriods ?? 5;
+    const datapointsToAlarm = props.datapointsToAlarm ?? 5;
+    const threshold = props.threshold ?? 0.05;
+    const treatMissingData = props.treatMissingData ?? cloudwatch.TreatMissingData.MISSING;
+    const alarmDescription = props.alarmDescription ?? 'This alarm can detect high rates of client-side errors for the'
+      + ' API Gateway requests.';
+
+    validateTotalAlarmPeriod(period, evaluationPeriods, alarmName);
+
+    super(scope, id, {
+      alarmName,
+      metric: props.api.metricClientError({
+        dimensionsMap: {
+          ApiName: props.api.restApiName,
+          Stage: props.api.deploymentStage.stageName,
+        },
+        statistic: 'Average',
+        period,
+      }),
+      threshold,
+      evaluationPeriods,
+      datapointsToAlarm,
+      treatMissingData,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      alarmDescription,
+    });
+
+    if (props.alarmAction) this.addAlarmAction(props.alarmAction);
+    if (props.okAction) this.addOkAction(props.okAction);
+    if (props.insufficientDataAction) this.addInsufficientDataAction(props.insufficientDataAction);
+  }
+};
+
+/**
+ * Configuration for the 5XXError alarm.
+ */
+export interface ApiGateway5XXErrorAlarmConfig extends ApiGatewayAlarmBaseConfig {
+  /**
+   * The percentage (0-1) value against which the specified statistic is compared.
+   * The suggested threshold detects when more than 5% of total requests are getting 5XX errors.
+   * However, you can tune the threshold to suit the traffic of the requests as well as acceptable
+   * error rates. you can also analyze historical data to determine the acceptable error rate for
+   * the application workload and then tune the threshold accordingly. Frequently occurring 5XX
+   * errors need to be alarmed on. However, setting a very low value for the threshold can cause
+   * the alarm to be too sensitive.
+   *
+   * @default 0.05
+   */
+  readonly threshold?: number;
+  /**
+   * The number of periods over which data is compared to the specified threshold.
+   *
+   * @default 3
+   */
+  readonly evaluationPeriods?: number;
+  /**
+   * The number of data points that must be breaching to trigger the alarm.
+   *
+   * @default 3
+   */
+  readonly datapointsToAlarm?: number;
+  /**
+   * The alarm name.
+   *
+   * @default - apiName + ' - 5XXError'
+   */
+  readonly alarmName?: string;
+  /**
+   * The description of the alarm.
+   *
+   * @default - This alarm can detect high rates of server-side errors for the API Gateway requests.
+   */
+  readonly alarmDescription?: string;
+}
+
+/**
+ * The properties for the ApiGatewayRestApi5XXErrorAlarm construct.
+ */
+export interface ApiGatewayRestApi5XXErrorAlarmProps extends ApiGatewayRestApiAlarmProps, ApiGateway5XXErrorAlarmConfig {}
+
+/**
+ * This alarm detects a high rate of server-side errors.
+ *
+ * This can indicate that there is something wrong on the API backend, the network,
+ * or the integration between the API gateway and the backend API.
+ *
+ * The alarm is triggered when percentage of server-errors exceeds the threshold.
+ */
+export class ApiGatewayRestApi5XXErrorAlarm extends cloudwatch.Alarm {
+  constructor(scope: IConstruct, id: string, props: ApiGatewayRestApi5XXErrorAlarmProps) {
+    const alarmName = props.alarmName ?? `${props.api.restApiName} - ${ApiGatewayRecommendedAlarmsMetrics.ERROR_5XX}`;
+    const period = props.period ?? Duration.minutes(1);
+    const evaluationPeriods = props.evaluationPeriods ?? 3;
+    const datapointsToAlarm = props.datapointsToAlarm ?? 3;
+    const threshold = props.threshold ?? 0.05;
+    const treatMissingData = props.treatMissingData ?? cloudwatch.TreatMissingData.MISSING;
+    const alarmDescription = props.alarmDescription ?? 'This alarm can detect high rates of server-side errors for the'
+      + ' API Gateway requests.';
+
+    validateTotalAlarmPeriod(period, evaluationPeriods, alarmName);
+
+    super(scope, id, {
+      alarmName,
+      metric: props.api.metricServerError({
+        dimensionsMap: {
+          ApiName: props.api.restApiName,
+          Stage: props.api.deploymentStage.stageName,
+        },
+        statistic: 'Average',
+        period,
+      }),
+      threshold,
+      evaluationPeriods,
+      datapointsToAlarm,
+      treatMissingData,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+      alarmDescription,
+    });
+
+    if (props.alarmAction) this.addAlarmAction(props.alarmAction);
+    if (props.okAction) this.addOkAction(props.okAction);
+    if (props.insufficientDataAction) this.addInsufficientDataAction(props.insufficientDataAction);
+  }
+};
+
+/**
+ * Configuration for the Count alarm.
+ */
+export interface ApiGatewayCountAlarmConfig extends ApiGatewayAlarmBaseConfig {
+  /**
+   * The value against which the specified statistic is compared.
+   * Set the threshold based on historical data analysis to determine what the expected
+   * baseline request count for your API is. Setting the threshold at a very high value
+   * might cause the alarm to be too sensitive at periods of normal and expected low traffic.
+   * Conversely, setting it at a very low value might cause the alarm to miss anomalous
+   * smaller drops in traffic volume.
+   *
+   */
+  readonly threshold: number;
+  /**
+   * The number of periods over which data is compared to the specified threshold.
+   *
+   * @default 10
+   */
+  readonly evaluationPeriods?: number;
+  /**
+   * The number of data points that must be breaching to trigger the alarm.
+   *
+   * @default 10
+   */
+  readonly datapointsToAlarm?: number;
+  /**
+   * The alarm name.
+   *
+   * @default - apiName + ' - Count'
+   */
+  readonly alarmName?: string;
+  /**
+   * The description of the alarm.
+   *
+   * @default - This alarm can detect high rates of client-side errors for the API Gateway requests.
+   */
+  readonly alarmDescription?: string;
+}
+
+/**
+ * The properties for the ApiGatewayRestApiCountAlarm construct.
+ */
+export interface ApiGatewayRestApiCountAlarmProps extends ApiGatewayRestApiAlarmProps, ApiGatewayCountAlarmConfig {}
+
+/**
+ * This alarm helps to detect low traffic volume for the REST API stage.
+ *
+ * This can be an indicator of an issue with the application calling the API such as using incorrect endpoints.
+ * It could also be an indicator of an issue with the configuration or permissions of the API making it unreachable
+ * for clients.
+ *
+ * The alarm is triggered when the number of requests in a given period is less than threshold.
+ */
+export class ApiGatewayRestApiCountAlarm extends cloudwatch.Alarm {
+  constructor(scope: IConstruct, id: string, props: ApiGatewayRestApiCountAlarmProps) {
+    const alarmName = props.alarmName ?? `${props.api.restApiName} - ${ApiGatewayRecommendedAlarmsMetrics.COUNT}`;
+    const period = props.period ?? Duration.minutes(1);
+    const evaluationPeriods = props.evaluationPeriods ?? 10;
+    const datapointsToAlarm = props.datapointsToAlarm ?? 10;
+    const threshold = props.threshold;
+    const treatMissingData = props.treatMissingData ?? cloudwatch.TreatMissingData.MISSING;
+    const alarmDescription = props.alarmDescription ?? 'This alarm can detect unexpectedly low traffic volume for'
+      + ' the REST API stage.';
+
+    validateTotalAlarmPeriod(period, evaluationPeriods, alarmName);
+
+    super(scope, id, {
+      alarmName,
+      metric: props.api.metricCount({
+        dimensionsMap: {
+          ApiName: props.api.restApiName,
+          Stage: props.api.deploymentStage.stageName,
+        },
+        statistic: 'SampleCount',
+        period,
+      }),
+      threshold,
+      evaluationPeriods,
+      datapointsToAlarm,
+      treatMissingData,
+      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      alarmDescription,
+    });
+
+    if (props.alarmAction) this.addAlarmAction(props.alarmAction);
+    if (props.okAction) this.addOkAction(props.okAction);
+    if (props.insufficientDataAction) this.addInsufficientDataAction(props.insufficientDataAction);
+  }
+};
+
+/**
+ * Configuration for the Latency alarm.
+ */
+export interface ApiGatewayLatencyAlarmConfig extends ApiGatewayAlarmBaseConfig {
+  /**
+   * The value in milliseconds against which the specified statistic is compared.
+   * The suggested threshold value does not work for all API workloads. However, you can
+   * use it as a starting point for the threshold. You can then choose different threshold
+   * values based on the workload and acceptable latency, performance, and SLA requirements
+   * for the API. If it is acceptable for the API to have a higher latency in general, you
+   * can set a higher threshold value to make the alarm less sensitive. However, if the API
+   * is expected to provide near real-time responses, set a lower threshold value. You can
+   * also analyze historical data to determine what the expected baseline latency is for the
+   * application workload and then tune the threshold value accordingly.
+   *
+   * @default 2500
+   */
+  readonly threshold?: number;
+  /**
+   * The number of periods over which data is compared to the specified threshold.
+   *
+   * @default 5
+   */
+  readonly evaluationPeriods?: number;
+  /**
+   * The number of data points that must be breaching to trigger the alarm.
+   *
+   * @default 5
+   */
+  readonly datapointsToAlarm?: number;
+  /**
+   * The alarm name.
+   *
+   * @default - apiName + ' - Latency'
+   */
+  readonly alarmName?: string;
+  /**
+   * The description of the alarm.
+   *
+   * @default - This alarm can detect when the API Gateway requests in a stage have high latency.
+   */
+  readonly alarmDescription?: string;
+}
+
+/**
+ * The properties for the ApiGatewayRestApiLatencyAlarm construct.
+ */
+export interface ApiGatewayRestApiLatencyAlarmProps extends ApiGatewayRestApiAlarmProps, ApiGatewayLatencyAlarmConfig {}
+
+/**
+ * This alarm can detect when the API Gateway requests in a stage have high latency.
+ *
+ *  If you have detailed CloudWatch metrics enabled and you have different latency performance
+ * requirements for each method and resource, we recommend that you create alternative alarms to
+ * have more fine-grained monitoring of the latency for each resource and method.
+ *
+ * The alarm is triggered when time in milliseconds exceeds or equals the threshold.
+ */
+export class ApiGatewayRestApiLatencyAlarm extends cloudwatch.Alarm {
+  constructor(scope: IConstruct, id: string, props: ApiGatewayRestApiLatencyAlarmProps) {
+    const alarmName = props.alarmName ?? `${props.api.restApiName} - ${ApiGatewayRecommendedAlarmsMetrics.LATENCY}`;
+    const period = props.period ?? Duration.minutes(1);
+    const evaluationPeriods = props.evaluationPeriods ?? 5;
+    const datapointsToAlarm = props.datapointsToAlarm ?? 5;
+    const threshold = props.threshold ?? 2500;
+    const treatMissingData = props.treatMissingData ?? cloudwatch.TreatMissingData.MISSING;
+    const alarmDescription = props.alarmDescription ?? 'This alarm can detect when the API Gateway requests in a'
+      + ' stage have high latency.';
+
+    validateTotalAlarmPeriod(period, evaluationPeriods, alarmName);
+
+    super(scope, id, {
+      alarmName,
+      metric: props.api.metricLatency({
+        dimensionsMap: {
+          ApiName: props.api.restApiName,
+          Stage: props.api.deploymentStage.stageName,
+        },
+        statistic: 'p90',
+        period,
+      }),
+      threshold,
+      evaluationPeriods,
+      datapointsToAlarm,
+      treatMissingData,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      alarmDescription,
+    });
+
+    if (props.alarmAction) this.addAlarmAction(props.alarmAction);
+    if (props.okAction) this.addOkAction(props.okAction);
+    if (props.insufficientDataAction) this.addInsufficientDataAction(props.insufficientDataAction);
+  }
+};
+
+/**
+ * Configuration for the Count alarm when monitoring resource and method dimensions.
+ */
+export interface ApiGatewayRestApiDetailedCountAlarmConfig extends
+  ApiGatewayCountAlarmConfig,
+  ApiGatewayDetailedAlarmConfig {}
+
+/**
+ * The properties for the ApiGatewayRestApiDetailedCountAlarm construct.
+ */
+export interface ApiGatewayRestApiDetailedCountAlarmProps extends
+  ApiGatewayRestApiAlarmProps,
+  ApiGatewayCountAlarmConfig,
+  ApiGatewayDetailedAlarmConfig {}
+
+/**
+ * This alarm can detect unexpectedly low traffic volume for the REST API resource and method
+ * in the stage.
+ *
+ * We recommend that you create this alarm if your API receives a predictable and
+ * consistent number of requests under normal conditions. This alarm is not recommended for APIs
+ * that don't expect constant and consistent traffic.
+ *
+ * The alarm is triggered when the number of requests in a given period is less than threshold.
+ */
+export class ApiGatewayRestApiDetailedCountAlarm extends cloudwatch.Alarm {
+  constructor(scope: IConstruct, id: string, props: ApiGatewayRestApiDetailedCountAlarmProps) {
+    const alarmName = props.alarmName ?? `${props.api.restApiName}-${props.alias} - ${ApiGatewayRecommendedAlarmsMetrics.COUNT}`;
+    const period = props.period ?? Duration.minutes(1);
+    const evaluationPeriods = props.evaluationPeriods ?? 10;
+    const datapointsToAlarm = props.datapointsToAlarm ?? 10;
+    const threshold = props.threshold;
+    const treatMissingData = props.treatMissingData ?? cloudwatch.TreatMissingData.MISSING;
+    const alarmDescription = props.alarmDescription ?? 'This alarm can detect when the API Gateway requests for a'
+      + ' resource and method in a stage have high latency.';
+
+    validateTotalAlarmPeriod(period, evaluationPeriods, alarmName);
+
+    super(scope, id, {
+      alarmName,
+      metric: props.api.metricCount({
+        dimensionsMap: {
+          ApiName: props.api.restApiName,
+          Stage: props.api.deploymentStage.stageName,
+          Resource: props.resource,
+          Method: props.method,
+        },
+        statistic: 'SampleCount',
+        period,
+      }),
+      threshold,
+      evaluationPeriods,
+      datapointsToAlarm,
+      treatMissingData,
+      comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+      alarmDescription,
+    });
+
+    if (props.alarmAction) this.addAlarmAction(props.alarmAction);
+    if (props.okAction) this.addOkAction(props.okAction);
+    if (props.insufficientDataAction) this.addInsufficientDataAction(props.insufficientDataAction);
+  }
+};
+
+/**
+ * Configuration for the Latency alarm when monitoring resource and method dimensions.
+ */
+export interface ApiGatewayRestApiDetailedLatencyAlarmConfig extends
+  ApiGatewayLatencyAlarmConfig,
+  ApiGatewayDetailedAlarmConfig {}
+
+/**
+ * The properties for the ApiGatewayRestApiDetailedLatencyAlarm construct.
+ */
+export interface ApiGatewayRestApiDetailedLatencyAlarmProps extends
+  ApiGatewayRestApiAlarmProps,
+  ApiGatewayLatencyAlarmConfig,
+  ApiGatewayDetailedAlarmConfig {}
+
+/**
+ * This alarm detects high latency for a resource and method in a stage.
+ *
+ * Find the IntegrationLatency metric value to check the API backend latency. If the two
+ * metrics are mostly aligned, the API backend is the source of higher latency and you should
+ * investigate there for performance issues. Consider also enabling CloudWatch Logs and checking
+ * for any errors that might be causing the high latency.
+ *
+ * The alarm is triggered when time in milliseconds exceeds or equals the threshold.
+ */
+export class ApiGatewayRestApiDetailedLatencyAlarm extends cloudwatch.Alarm {
+  constructor(scope: IConstruct, id: string, props: ApiGatewayRestApiDetailedLatencyAlarmProps) {
+    const alarmName = props.alarmName ?? `${props.api.restApiName}-${props.alias} - ${ApiGatewayRecommendedAlarmsMetrics.LATENCY}`;
+    const period = props.period ?? Duration.minutes(1);
+    const evaluationPeriods = props.evaluationPeriods ?? 5;
+    const datapointsToAlarm = props.datapointsToAlarm ?? 5;
+    const threshold = props.threshold ?? 2500;
+    const treatMissingData = props.treatMissingData ?? cloudwatch.TreatMissingData.MISSING;
+    const alarmDescription = props.alarmDescription ?? 'This alarm can detect when the API Gateway requests for a'
+      + ' resource and method in a stage have high latency.';
+
+    validateTotalAlarmPeriod(period, evaluationPeriods, alarmName);
+
+    super(scope, id, {
+      alarmName,
+      metric: props.api.metricLatency({
+        dimensionsMap: {
+          ApiName: props.api.restApiName,
+          Stage: props.api.deploymentStage.stageName,
+          Resource: props.resource,
+          Method: props.method,
+        },
+        statistic: 'p90',
+        period,
+      }),
+      threshold,
+      evaluationPeriods,
+      datapointsToAlarm,
+      treatMissingData,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+      alarmDescription,
+    });
+
+    if (props.alarmAction) this.addAlarmAction(props.alarmAction);
+    if (props.okAction) this.addOkAction(props.okAction);
+    if (props.insufficientDataAction) this.addInsufficientDataAction(props.insufficientDataAction);
+  }
+};
+
+/**
+ * Configurations for the recommended alarms for an ApiGateway RestApi.
+ *
+ * Default actions are overridden by the actions specified in the
+ * individual alarm configurations.
+ */
+export interface ApiGatewayRestApiRecommendedAlarmsConfig {
+  /**
+   * The default action to take when an alarm is triggered.
+   *
+   * @default - None
+   */
+  readonly defaultAlarmAction?: cloudwatch.IAlarmAction;
+  /**
+   * The default action to take when an alarm enters the ok state.
+   *
+   * @default - None
+   */
+  readonly defaultOkAction?: cloudwatch.IAlarmAction;
+  /**
+   * The default action to take when an alarm has insufficient data.
+   *
+   * @default - None
+   */
+  readonly defaultInsufficientDataAction?: cloudwatch.IAlarmAction;
+  /**
+   * How to handle missing data for this alarm.
+   *
+   * @default TreatMissingData.MISSING
+   */
+  readonly treatMissingData?: cloudwatch.TreatMissingData;
+  /**
+   * Alarm metrics to exclude from the recommended alarms.
+   *
+   * @default - None
+   */
+  readonly excludeAlarms?: ApiGatewayRecommendedAlarmsMetrics[];
+  /**
+   * The resources to exclude from the recommended alarms.
+   *
+   * Use a resources id to exclude a specific resource.
+   */
+  readonly excludeResources?: string[];
+  /**
+   * The configuration for the 4XXError alarm.
+   */
+  readonly config4XXErrorAlarm?: ApiGateway4XXErrorAlarmConfig;
+  /**
+   * The configuration for the 5XXError alarm.
+   */
+  readonly config5XXErrorAlarm?: ApiGateway5XXErrorAlarmConfig;
+  /**
+   * The configuration for the Count alarm.
+   */
+  readonly configCountAlarm: ApiGatewayCountAlarmConfig;
+  /**
+   * The configuration for the Latency alarm.
+   */
+  readonly configLatencyAlarm?: ApiGatewayLatencyAlarmConfig;
+  /**
+   * The configuration list for the detailed Count alarm.
+   */
+  readonly configDetailedCountAlarmList?: ApiGatewayRestApiDetailedCountAlarmConfig[];
+  /**
+   * The configuration list for the detailed Latency alarm.
+   */
+  readonly configDetailedLatencyAlarmList?: ApiGatewayRestApiDetailedLatencyAlarmConfig[];
+}
+
+/**
+ * Properties for the ApiGatewayRestApiRecommendedAlarms construct.
+ */
+export interface ApiGatewayRestApiRecommendedAlarmsProps extends ApiGatewayRestApiRecommendedAlarmsConfig {
+  /**
+   * The ApiGateway api to monitor.
+   */
+  readonly api: apigateway.RestApi;
+}
+
+/**
+ * A construct that creates the recommended alarms for an ApiGateway api.
+ *
+ * The recommended alarms created by default for the ApiName and Stage are:
+ * - 4XXError alarm
+ * - 5XXError alarm
+ * - Count alarm
+ * - Latency alarm
+ *
+ * In order to create the Count or Latency alarms for the Resource and Method dimensions the
+ * configDetailedCountAlarmList or configDetailedLatencyAlarmList must be specified.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#ApiGateway
+ */
+export class ApiGatewayRestApiRecommendedAlarms extends Construct {
+  /**
+   * The 4XXError alarm.
+   */
+  public readonly alarm4XXError?: ApiGatewayRestApi4XXErrorAlarm;
+
+  /**
+   * The 5XXError alarm.
+   */
+  public readonly alarm5XXError?: ApiGatewayRestApi5XXErrorAlarm;
+
+  /**
+   * The Count alarm.
+   */
+  public readonly alarmCount?: ApiGatewayRestApiCountAlarm;
+
+  /**
+   * The Latency alarm.
+   */
+  public readonly alarmLatency?: ApiGatewayRestApiLatencyAlarm;
+
+  constructor(scope: Construct, id: string, props: ApiGatewayRestApiRecommendedAlarmsProps) {
+    super(scope, id);
+
+    if (!props.excludeAlarms?.includes(ApiGatewayRecommendedAlarmsMetrics.ERROR_4XX)) {
+      this.alarm4XXError = new ApiGatewayRestApi4XXErrorAlarm(this, `${props.api.node.id}_4XXError`, {
+        api: props.api,
+        ...props.config4XXErrorAlarm,
+      });
+
+      if (props.defaultAlarmAction && !props.config4XXErrorAlarm?.alarmAction) {
+        this.alarm4XXError.addAlarmAction(props.defaultAlarmAction);
+      }
+
+      if (props.defaultOkAction && !props.config4XXErrorAlarm?.okAction) {
+        this.alarm4XXError.addOkAction(props.defaultOkAction);
+      }
+
+      if (props.defaultInsufficientDataAction && !props.config4XXErrorAlarm?.insufficientDataAction) {
+        this.alarm4XXError.addInsufficientDataAction(props.defaultInsufficientDataAction);
+      }
+    }
+
+    if (!props.excludeAlarms?.includes(ApiGatewayRecommendedAlarmsMetrics.ERROR_5XX)) {
+      this.alarm5XXError = new ApiGatewayRestApi5XXErrorAlarm(this, `${props.api.node.id}_5XXError`, {
+        api: props.api,
+        ...props.config5XXErrorAlarm,
+      });
+
+      if (props.defaultAlarmAction && !props.config5XXErrorAlarm?.alarmAction) {
+        this.alarm5XXError.addAlarmAction(props.defaultAlarmAction);
+      }
+
+      if (props.defaultOkAction && !props.config5XXErrorAlarm?.okAction) {
+        this.alarm5XXError.addOkAction(props.defaultOkAction);
+      }
+
+      if (props.defaultInsufficientDataAction && !props.config5XXErrorAlarm?.insufficientDataAction) {
+        this.alarm5XXError.addInsufficientDataAction(props.defaultInsufficientDataAction);
+      }
+    }
+
+    if (!props.excludeAlarms?.includes(ApiGatewayRecommendedAlarmsMetrics.COUNT)) {
+      this.alarmCount = new ApiGatewayRestApiCountAlarm(this, `${props.api.node.id}_Count`, {
+        api: props.api,
+        ...props.configCountAlarm,
+      });
+
+      if (props.defaultAlarmAction && !props.configCountAlarm.alarmAction) {
+        this.alarmCount.addAlarmAction(props.defaultAlarmAction);
+      }
+
+      if (props.defaultOkAction && !props.configCountAlarm.okAction) {
+        this.alarmCount.addOkAction(props.defaultOkAction);
+      }
+
+      if (props.defaultInsufficientDataAction && !props.configCountAlarm.insufficientDataAction) {
+        this.alarmCount.addInsufficientDataAction(props.defaultInsufficientDataAction);
+      }
+    }
+
+    if (!props.excludeAlarms?.includes(ApiGatewayRecommendedAlarmsMetrics.LATENCY)) {
+      this.alarmLatency = new ApiGatewayRestApiLatencyAlarm(this, `${props.api.node.id}_Latency`, {
+        api: props.api,
+        ...props.configLatencyAlarm,
+      });
+
+      if (props.defaultAlarmAction && !props.configLatencyAlarm?.alarmAction) {
+        this.alarmLatency.addAlarmAction(props.defaultAlarmAction);
+      }
+
+      if (props.defaultOkAction && !props.configLatencyAlarm?.okAction) {
+        this.alarmLatency.addOkAction(props.defaultOkAction);
+      }
+
+      if (props.defaultInsufficientDataAction && !props.configLatencyAlarm?.insufficientDataAction) {
+        this.alarmLatency.addInsufficientDataAction(props.defaultInsufficientDataAction);
+      }
+    }
+
+    if (!props.excludeAlarms?.includes(ApiGatewayRecommendedAlarmsMetrics.COUNT) && props.configDetailedCountAlarmList) {
+      props.configDetailedCountAlarmList.forEach((config, index) => {
+        let alarmConfig = {
+          api: props.api,
+          ...config,
+        };
+        if (props.defaultAlarmAction && !config.alarmAction) {
+          alarmConfig = { ...alarmConfig, alarmAction: props.defaultAlarmAction };
+        }
+        if (props.defaultOkAction && !config.okAction) {
+          alarmConfig = { ...alarmConfig, okAction: props.defaultOkAction };
+        }
+        if (props.defaultInsufficientDataAction && !config.insufficientDataAction) {
+          alarmConfig = { ...alarmConfig, insufficientDataAction: props.defaultInsufficientDataAction };
+        }
+        new ApiGatewayRestApiDetailedCountAlarm(this, `${props.api.node.id}_DetailedCount${index}`, alarmConfig);
+      });
+    }
+
+    if (!props.excludeAlarms?.includes(ApiGatewayRecommendedAlarmsMetrics.LATENCY) && props.configDetailedLatencyAlarmList) {
+      props.configDetailedLatencyAlarmList.forEach((config, index) => {
+        let alarmConfig = {
+          api: props.api,
+          ...config,
+        };
+        if (props.defaultAlarmAction && !config.alarmAction) {
+          alarmConfig = { ...alarmConfig, alarmAction: props.defaultAlarmAction };
+        }
+        if (props.defaultOkAction && !config.okAction) {
+          alarmConfig = { ...alarmConfig, okAction: props.defaultOkAction };
+        }
+        if (props.defaultInsufficientDataAction && !config.insufficientDataAction) {
+          alarmConfig = { ...alarmConfig, insufficientDataAction: props.defaultInsufficientDataAction };
+        }
+        new ApiGatewayRestApiDetailedLatencyAlarm(this, `${props.api.node.id}_DetailedLatency${index}`, alarmConfig);
+      });
+    }
+  }
+}
+
+/**
+ * An extension for the RestApi construct that provides methods
+ * to create recommended alarms.
+ */
+export class RestApi extends apigateway.RestApi {
+  constructor(scope: Construct, id: string, props: apigateway.RestApiBaseProps) {
+    super(scope, id, props);
+  }
+
+  /**
+   * Creates an alarm that monitors the number of client-side errors captured in a given period.
+   */
+  public alarm4XXError(props?: ApiGateway4XXErrorAlarmConfig): ApiGatewayRestApi4XXErrorAlarm {
+    return new ApiGatewayRestApi4XXErrorAlarm(this, '4XXErrorAlarm', {
+      api: this,
+      ...props,
+    });
+  }
+
+  /**
+   * Creates an alarm that monitors the number of server-side errors captured in a given period.
+   */
+  public alarm5XXError(props?: ApiGateway5XXErrorAlarmConfig): ApiGatewayRestApi5XXErrorAlarm {
+    return new ApiGatewayRestApi5XXErrorAlarm(this, '5XXErrorAlarm', {
+      api: this,
+      ...props,
+    });
+  }
+
+  /**
+   * Creates an alarm that monitors the total number API requests in a given period.
+   */
+  public alarmCount(props: ApiGatewayCountAlarmConfig): ApiGatewayRestApiCountAlarm {
+    return new ApiGatewayRestApiCountAlarm(this, 'CountAlarm', {
+      api: this,
+      ...props,
+    });
+  }
+
+  /**
+   * Creates an alarm that monitors the time between when API Gateway receives a request
+   * from a client and when it returns a response to the client.
+   */
+  public alarmLatency(props?: ApiGatewayLatencyAlarmConfig): ApiGatewayRestApiLatencyAlarm {
+    return new ApiGatewayRestApiLatencyAlarm(this, 'LatencyAlarm', {
+      api: this,
+      ...props,
+    });
+  }
+
+  /**
+   * Creates a list of alarms that monitor the total number API requests in a given period for
+   * the methods and resources specified.
+   */
+  public alarmDetailedCount(props: ApiGatewayRestApiDetailedCountAlarmConfig[]): ApiGatewayRestApiDetailedCountAlarm[] {
+    let alarmList: ApiGatewayRestApiDetailedCountAlarm[] = [];
+
+    props.forEach((config, index) => {
+      const alarm = new ApiGatewayRestApiDetailedCountAlarm(this, `DetailedCount${index}`, {
+        api: this,
+        ...config,
+      });
+      alarmList.push(alarm);
+    });
+    return alarmList;
+  }
+
+  /**
+   * Creates a list of alarms the time between when API Gateway receives a request
+   * from a client and when it returns a response to the client for the methods and
+   * resources specified.
+   */
+  public alarmDetailedLatency(props: ApiGatewayRestApiDetailedLatencyAlarmConfig[]): ApiGatewayRestApiDetailedLatencyAlarm[] {
+    let alarmList: ApiGatewayRestApiDetailedLatencyAlarm[] = [];
+
+    props.forEach((config, index) => {
+      const alarm = new ApiGatewayRestApiDetailedLatencyAlarm(this, `DetailedLatency${index}`, {
+        api: this,
+        ...config,
+      });
+      alarmList.push(alarm);
+    });
+    return alarmList;
+  }
+
+  /**
+   * Creates the recommended alarms for the ApiGateway api.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#ApiGateway
+   */
+  public applyRecommendedAlarms(props: ApiGatewayRestApiRecommendedAlarmsConfig): ApiGatewayRestApiRecommendedAlarms {
+    return new ApiGatewayRestApiRecommendedAlarms(this, 'ApiGatewayRestApiRecommendedAlarms', {
+      api: this,
+      ...props,
+    });
+  }
+}
+
+/**
+ * Configures the recommended alarms for an ApiGateway api.
+ *
+ * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Best_Practice_Recommended_Alarms_AWS_Services.html#ApiGateway
+ */
+export class ApiGatewayRecommendedAlarmsAspect implements IAspect {
+  constructor(private readonly props: ApiGatewayRestApiRecommendedAlarmsConfig) {}
+
+  public visit(node: IConstruct): void {
+    if (node instanceof apigateway.RestApi) {
+      if (this.props.excludeResources && this.props.excludeResources.includes(node.node.id)) {
+        return;
+      } else {
+        const api = node as apigateway.RestApi;
+
+        new ApiGatewayRestApiRecommendedAlarms(api, 'ApiGatewayRestApiRecommendedAlarmsFromAspect', {
+          api,
+          ...this.props,
+        });
+      }
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './apigateway';
 export * from './common';
 export * from './ecs';
 export * from './efs';

--- a/test/__snapshots__/apigateway.test.ts.snap
+++ b/test/__snapshots__/apigateway.test.ts.snap
@@ -1,0 +1,4784 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RestApiSnapshot 1`] = `
+Object {
+  "Outputs": Object {
+    "RestApiEndpoint0551178A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "RestApi0C43BF4B": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiANYA7C1DC94": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiAccount7C83CF5A": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApi4XXError6FA6D9EE": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of client-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 4XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApi5XXErrorB8ED282A": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of server-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 5XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApiCountF4908B9F": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect unexpectedly low traffic volume for the REST API stage.",
+        "AlarmName": "TestApi - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApiLatencyFB41F7A4": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect when the API Gateway requests in a stage have high latency.",
+        "AlarmName": "TestApi - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiCloudWatchRoleE3ED6605": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e": Object {
+      "DependsOn": Array [
+        "RestApiproxyANY1786B242",
+        "RestApiproxyC95856DD",
+        "RestApiANYA7C1DC94",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageliveE585F0C9": Object {
+      "DependsOn": Array [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "testApiAccessLogGroup1F4A8AE6",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"method\\":\\"$context.httpMethod\\",\\"userContext\\":{\\"apiKeyId\\":\\"$context.identity.apiKeyId\\",\\"userAgent\\":\\"$context.identity.userAgent\\"},\\"requestPath\\":\\"$context.path\\",\\"requestTime\\":\\"$context.requestTime\\",\\"error\\":{\\"message\\":\\"$context.error.message\\",\\"responseType\\":\\"$context.error.responseType\\"},\\"waf\\":{\\"responseCode\\":\\"$context.wafResponseCode\\",\\"error\\":\\"$context.waf.error\\",\\"latency\\":\\"$context.waf.latency\\",\\"status\\":\\"$context.waf.status\\"},\\"integration\\":{\\"error\\":\\"$context.integrationErrorMessage\\",\\"latency\\":\\"$context.integrationLatency\\",\\"status\\":\\"$context.integrationStatus\\"},\\"authorizer\\":{\\"error\\":\\"$context.authorizer.error\\",\\"latency\\":\\"$context.authorizer.latency\\",\\"status\\":\\"$context.authorizer.status\\",\\"integration\\":{\\"latency\\":\\"$context.authorizer.integrationLatency\\",\\"status\\":\\"$context.authorizer.integrationStatus\\"}},\\"customDomainBasePath\\":\\"$context.customDomain.basePathMatched\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"status\\":\\"$context.status\\"}",
+        },
+        "DeploymentId": Object {
+          "Ref": "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApiproxyANY1786B242": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApiproxyC95856DD",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiproxyC95856DD": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "testApiAccessLogGroup1F4A8AE6": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "LogGroupName": "/apigateway/testapi/accesslogs",
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`RestApiSnapshotDefaultActionsInUse 1`] = `
+Object {
+  "Outputs": Object {
+    "RestApiEndpoint0551178A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "RestApi0C43BF4B": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiANYA7C1DC94": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiAccount7C83CF5A": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiCloudWatchRoleE3ED6605": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e": Object {
+      "DependsOn": Array [
+        "RestApiproxyANY1786B242",
+        "RestApiproxyC95856DD",
+        "RestApiANYA7C1DC94",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageliveE585F0C9": Object {
+      "DependsOn": Array [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "testApiAccessLogGroup1F4A8AE6",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"method\\":\\"$context.httpMethod\\",\\"userContext\\":{\\"apiKeyId\\":\\"$context.identity.apiKeyId\\",\\"userAgent\\":\\"$context.identity.userAgent\\"},\\"requestPath\\":\\"$context.path\\",\\"requestTime\\":\\"$context.requestTime\\",\\"error\\":{\\"message\\":\\"$context.error.message\\",\\"responseType\\":\\"$context.error.responseType\\"},\\"waf\\":{\\"responseCode\\":\\"$context.wafResponseCode\\",\\"error\\":\\"$context.waf.error\\",\\"latency\\":\\"$context.waf.latency\\",\\"status\\":\\"$context.waf.status\\"},\\"integration\\":{\\"error\\":\\"$context.integrationErrorMessage\\",\\"latency\\":\\"$context.integrationLatency\\",\\"status\\":\\"$context.integrationStatus\\"},\\"authorizer\\":{\\"error\\":\\"$context.authorizer.error\\",\\"latency\\":\\"$context.authorizer.latency\\",\\"status\\":\\"$context.authorizer.status\\",\\"integration\\":{\\"latency\\":\\"$context.authorizer.integrationLatency\\",\\"status\\":\\"$context.authorizer.integrationStatus\\"}},\\"customDomainBasePath\\":\\"$context.customDomain.basePathMatched\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"status\\":\\"$context.status\\"}",
+        },
+        "DeploymentId": Object {
+          "Ref": "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApiproxyANY1786B242": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApiproxyC95856DD",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiproxyC95856DD": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "TopicBFC7AF6E": Object {
+      "Type": "AWS::SNS::Topic",
+    },
+    "apiGatewayRestApiAlarmsRestApi4XXError8B075579": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect high rates of client-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 4XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApi5XXError005F45E2": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect high rates of server-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 5XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApiCountB292920F": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect unexpectedly low traffic volume for the REST API stage.",
+        "AlarmName": "TestApi - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApiLatencyCD758518": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect when the API Gateway requests in a stage have high latency.",
+        "AlarmName": "TestApi - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "testApiAccessLogGroup1F4A8AE6": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "LogGroupName": "/apigateway/testapi/accesslogs",
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`RestApiSnapshotDefaultActionsInUseWithDetails 1`] = `
+Object {
+  "Outputs": Object {
+    "RestApiEndpoint0551178A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "RestApi0C43BF4B": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiANYA7C1DC94": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiAccount7C83CF5A": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiCloudWatchRoleE3ED6605": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e": Object {
+      "DependsOn": Array [
+        "RestApiproxyANY1786B242",
+        "RestApiproxyC95856DD",
+        "RestApiANYA7C1DC94",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageliveE585F0C9": Object {
+      "DependsOn": Array [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "testApiAccessLogGroup1F4A8AE6",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"method\\":\\"$context.httpMethod\\",\\"userContext\\":{\\"apiKeyId\\":\\"$context.identity.apiKeyId\\",\\"userAgent\\":\\"$context.identity.userAgent\\"},\\"requestPath\\":\\"$context.path\\",\\"requestTime\\":\\"$context.requestTime\\",\\"error\\":{\\"message\\":\\"$context.error.message\\",\\"responseType\\":\\"$context.error.responseType\\"},\\"waf\\":{\\"responseCode\\":\\"$context.wafResponseCode\\",\\"error\\":\\"$context.waf.error\\",\\"latency\\":\\"$context.waf.latency\\",\\"status\\":\\"$context.waf.status\\"},\\"integration\\":{\\"error\\":\\"$context.integrationErrorMessage\\",\\"latency\\":\\"$context.integrationLatency\\",\\"status\\":\\"$context.integrationStatus\\"},\\"authorizer\\":{\\"error\\":\\"$context.authorizer.error\\",\\"latency\\":\\"$context.authorizer.latency\\",\\"status\\":\\"$context.authorizer.status\\",\\"integration\\":{\\"latency\\":\\"$context.authorizer.integrationLatency\\",\\"status\\":\\"$context.authorizer.integrationStatus\\"}},\\"customDomainBasePath\\":\\"$context.customDomain.basePathMatched\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"status\\":\\"$context.status\\"}",
+        },
+        "DeploymentId": Object {
+          "Ref": "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApiproxyANY1786B242": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApiproxyC95856DD",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiproxyC95856DD": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "TopicBFC7AF6E": Object {
+      "Type": "AWS::SNS::Topic",
+    },
+    "apiGatewayRestApiAlarmsRestApi4XXError8B075579": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect high rates of client-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 4XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApi5XXError005F45E2": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect high rates of server-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 5XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApiCountB292920F": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect unexpectedly low traffic volume for the REST API stage.",
+        "AlarmName": "TestApi - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApiDetailedCount01D7A175B": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect when the API Gateway requests for a resource and method in a stage have high latency.",
+        "AlarmName": "TestApi-getUsers - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Method",
+            "Value": "GET",
+          },
+          Object {
+            "Name": "Resource",
+            "Value": "/users",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 1000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApiDetailedCount140F6D885": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect when the API Gateway requests for a resource and method in a stage have high latency.",
+        "AlarmName": "TestApi-createUser - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Method",
+            "Value": "POST",
+          },
+          Object {
+            "Name": "Resource",
+            "Value": "/users",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 1000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApiDetailedLatency03D52684B": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect when the API Gateway requests for a resource and method in a stage have high latency.",
+        "AlarmName": "TestApi-getUsers - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Method",
+            "Value": "GET",
+          },
+          Object {
+            "Name": "Resource",
+            "Value": "/users",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApiDetailedLatency1E7B374F3": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect when the API Gateway requests for a resource and method in a stage have high latency.",
+        "AlarmName": "TestApi-createUser - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Method",
+            "Value": "POST",
+          },
+          Object {
+            "Name": "Resource",
+            "Value": "/users",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApiLatencyCD758518": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "This alarm can detect when the API Gateway requests in a stage have high latency.",
+        "AlarmName": "TestApi - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "testApiAccessLogGroup1F4A8AE6": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "LogGroupName": "/apigateway/testapi/accesslogs",
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`RestApiSnapshotWithDetailedList 1`] = `
+Object {
+  "Outputs": Object {
+    "RestApiEndpoint0551178A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "RestApi0C43BF4B": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiANYA7C1DC94": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiAccount7C83CF5A": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApi4XXError6FA6D9EE": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of client-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 4XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApi5XXErrorB8ED282A": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of server-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 5XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApiCountF4908B9F": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect unexpectedly low traffic volume for the REST API stage.",
+        "AlarmName": "TestApi - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApiDetailedCount032348565": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect when the API Gateway requests for a resource and method in a stage have high latency.",
+        "AlarmName": "TestApi-getUsers - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Method",
+            "Value": "GET",
+          },
+          Object {
+            "Name": "Resource",
+            "Value": "/users",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 1000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApiDetailedLatency04C0BC17C": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect when the API Gateway requests for a resource and method in a stage have high latency.",
+        "AlarmName": "TestApi-getUsers - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Method",
+            "Value": "GET",
+          },
+          Object {
+            "Name": "Resource",
+            "Value": "/users",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApiLatencyFB41F7A4": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect when the API Gateway requests in a stage have high latency.",
+        "AlarmName": "TestApi - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiCloudWatchRoleE3ED6605": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e": Object {
+      "DependsOn": Array [
+        "RestApiproxyANY1786B242",
+        "RestApiproxyC95856DD",
+        "RestApiANYA7C1DC94",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageliveE585F0C9": Object {
+      "DependsOn": Array [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "testApiAccessLogGroup1F4A8AE6",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"method\\":\\"$context.httpMethod\\",\\"userContext\\":{\\"apiKeyId\\":\\"$context.identity.apiKeyId\\",\\"userAgent\\":\\"$context.identity.userAgent\\"},\\"requestPath\\":\\"$context.path\\",\\"requestTime\\":\\"$context.requestTime\\",\\"error\\":{\\"message\\":\\"$context.error.message\\",\\"responseType\\":\\"$context.error.responseType\\"},\\"waf\\":{\\"responseCode\\":\\"$context.wafResponseCode\\",\\"error\\":\\"$context.waf.error\\",\\"latency\\":\\"$context.waf.latency\\",\\"status\\":\\"$context.waf.status\\"},\\"integration\\":{\\"error\\":\\"$context.integrationErrorMessage\\",\\"latency\\":\\"$context.integrationLatency\\",\\"status\\":\\"$context.integrationStatus\\"},\\"authorizer\\":{\\"error\\":\\"$context.authorizer.error\\",\\"latency\\":\\"$context.authorizer.latency\\",\\"status\\":\\"$context.authorizer.status\\",\\"integration\\":{\\"latency\\":\\"$context.authorizer.integrationLatency\\",\\"status\\":\\"$context.authorizer.integrationStatus\\"}},\\"customDomainBasePath\\":\\"$context.customDomain.basePathMatched\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"status\\":\\"$context.status\\"}",
+        },
+        "DeploymentId": Object {
+          "Ref": "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApiproxyANY1786B242": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApiproxyC95856DD",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiproxyC95856DD": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "testApiAccessLogGroup1F4A8AE6": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "LogGroupName": "/apigateway/testapi/accesslogs",
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`RestApiSnapshotWithExclusion 1`] = `
+Object {
+  "Outputs": Object {
+    "RestApiEndpoint0551178A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "RestApi0C43BF4B": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiANYA7C1DC94": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiAccount7C83CF5A": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApi5XXErrorB8ED282A": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of server-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 5XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApiCountF4908B9F": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect unexpectedly low traffic volume for the REST API stage.",
+        "AlarmName": "TestApi - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApiLatencyFB41F7A4": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect when the API Gateway requests in a stage have high latency.",
+        "AlarmName": "TestApi - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiCloudWatchRoleE3ED6605": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e": Object {
+      "DependsOn": Array [
+        "RestApiproxyANY1786B242",
+        "RestApiproxyC95856DD",
+        "RestApiANYA7C1DC94",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageliveE585F0C9": Object {
+      "DependsOn": Array [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "testApiAccessLogGroup1F4A8AE6",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"method\\":\\"$context.httpMethod\\",\\"userContext\\":{\\"apiKeyId\\":\\"$context.identity.apiKeyId\\",\\"userAgent\\":\\"$context.identity.userAgent\\"},\\"requestPath\\":\\"$context.path\\",\\"requestTime\\":\\"$context.requestTime\\",\\"error\\":{\\"message\\":\\"$context.error.message\\",\\"responseType\\":\\"$context.error.responseType\\"},\\"waf\\":{\\"responseCode\\":\\"$context.wafResponseCode\\",\\"error\\":\\"$context.waf.error\\",\\"latency\\":\\"$context.waf.latency\\",\\"status\\":\\"$context.waf.status\\"},\\"integration\\":{\\"error\\":\\"$context.integrationErrorMessage\\",\\"latency\\":\\"$context.integrationLatency\\",\\"status\\":\\"$context.integrationStatus\\"},\\"authorizer\\":{\\"error\\":\\"$context.authorizer.error\\",\\"latency\\":\\"$context.authorizer.latency\\",\\"status\\":\\"$context.authorizer.status\\",\\"integration\\":{\\"latency\\":\\"$context.authorizer.integrationLatency\\",\\"status\\":\\"$context.authorizer.integrationStatus\\"}},\\"customDomainBasePath\\":\\"$context.customDomain.basePathMatched\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"status\\":\\"$context.status\\"}",
+        },
+        "DeploymentId": Object {
+          "Ref": "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApiproxyANY1786B242": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApiproxyC95856DD",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiproxyC95856DD": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "testApiAccessLogGroup1F4A8AE6": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "LogGroupName": "/apigateway/testapi/accesslogs",
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`SnapshotForRestApiConstruct 1`] = `
+Object {
+  "Outputs": Object {
+    "RestApiEndpoint0551178A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "RestApi0C43BF4B": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiANYA7C1DC94": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiAccount7C83CF5A": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsRestApi4XXError24D17C36": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of client-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 4XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsRestApi5XXErrorF808FB4C": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of server-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 5XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsRestApiCount0920C293": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect unexpectedly low traffic volume for the REST API stage.",
+        "AlarmName": "TestApi - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsRestApiLatencyDD4ED868": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect when the API Gateway requests in a stage have high latency.",
+        "AlarmName": "TestApi - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiCloudWatchRoleE3ED6605": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e": Object {
+      "DependsOn": Array [
+        "RestApiproxyANY1786B242",
+        "RestApiproxyC95856DD",
+        "RestApiANYA7C1DC94",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageliveE585F0C9": Object {
+      "DependsOn": Array [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "testApiAccessLogGroup1F4A8AE6",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"method\\":\\"$context.httpMethod\\",\\"userContext\\":{\\"apiKeyId\\":\\"$context.identity.apiKeyId\\",\\"userAgent\\":\\"$context.identity.userAgent\\"},\\"requestPath\\":\\"$context.path\\",\\"requestTime\\":\\"$context.requestTime\\",\\"error\\":{\\"message\\":\\"$context.error.message\\",\\"responseType\\":\\"$context.error.responseType\\"},\\"waf\\":{\\"responseCode\\":\\"$context.wafResponseCode\\",\\"error\\":\\"$context.waf.error\\",\\"latency\\":\\"$context.waf.latency\\",\\"status\\":\\"$context.waf.status\\"},\\"integration\\":{\\"error\\":\\"$context.integrationErrorMessage\\",\\"latency\\":\\"$context.integrationLatency\\",\\"status\\":\\"$context.integrationStatus\\"},\\"authorizer\\":{\\"error\\":\\"$context.authorizer.error\\",\\"latency\\":\\"$context.authorizer.latency\\",\\"status\\":\\"$context.authorizer.status\\",\\"integration\\":{\\"latency\\":\\"$context.authorizer.integrationLatency\\",\\"status\\":\\"$context.authorizer.integrationStatus\\"}},\\"customDomainBasePath\\":\\"$context.customDomain.basePathMatched\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"status\\":\\"$context.status\\"}",
+        },
+        "DeploymentId": Object {
+          "Ref": "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApiproxyANY1786B242": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApiproxyC95856DD",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiproxyC95856DD": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "testApiAccessLogGroup1F4A8AE6": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "LogGroupName": "/apigateway/testapi/accesslogs",
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`alarms can be applied individually to services using extended construct 1`] = `
+Object {
+  "Outputs": Object {
+    "RestApiEndpoint0551178A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "RestApi0C43BF4B": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApi4XXErrorAlarm5ADD5D95": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of client-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 4XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi5XXErrorAlarm51BA79BF": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of server-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 5XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiANYA7C1DC94": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiAccount7C83CF5A": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiCloudWatchRoleE3ED6605": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiCountAlarmD1A5EDC9": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect unexpectedly low traffic volume for the REST API stage.",
+        "AlarmName": "TestApi - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e": Object {
+      "DependsOn": Array [
+        "RestApiproxyANY1786B242",
+        "RestApiproxyC95856DD",
+        "RestApiANYA7C1DC94",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageliveE585F0C9": Object {
+      "DependsOn": Array [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "testApiAccessLogGroup1F4A8AE6",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"method\\":\\"$context.httpMethod\\",\\"userContext\\":{\\"apiKeyId\\":\\"$context.identity.apiKeyId\\",\\"userAgent\\":\\"$context.identity.userAgent\\"},\\"requestPath\\":\\"$context.path\\",\\"requestTime\\":\\"$context.requestTime\\",\\"error\\":{\\"message\\":\\"$context.error.message\\",\\"responseType\\":\\"$context.error.responseType\\"},\\"waf\\":{\\"responseCode\\":\\"$context.wafResponseCode\\",\\"error\\":\\"$context.waf.error\\",\\"latency\\":\\"$context.waf.latency\\",\\"status\\":\\"$context.waf.status\\"},\\"integration\\":{\\"error\\":\\"$context.integrationErrorMessage\\",\\"latency\\":\\"$context.integrationLatency\\",\\"status\\":\\"$context.integrationStatus\\"},\\"authorizer\\":{\\"error\\":\\"$context.authorizer.error\\",\\"latency\\":\\"$context.authorizer.latency\\",\\"status\\":\\"$context.authorizer.status\\",\\"integration\\":{\\"latency\\":\\"$context.authorizer.integrationLatency\\",\\"status\\":\\"$context.authorizer.integrationStatus\\"}},\\"customDomainBasePath\\":\\"$context.customDomain.basePathMatched\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"status\\":\\"$context.status\\"}",
+        },
+        "DeploymentId": Object {
+          "Ref": "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApiDetailedCount06463A2AA": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect when the API Gateway requests for a resource and method in a stage have high latency.",
+        "AlarmName": "TestApi-getUsers - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Method",
+            "Value": "GET",
+          },
+          Object {
+            "Name": "Resource",
+            "Value": "/users",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 1000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiDetailedLatency0BBBD13CD": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect when the API Gateway requests for a resource and method in a stage have high latency.",
+        "AlarmName": "TestApi-getUsers - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Method",
+            "Value": "GET",
+          },
+          Object {
+            "Name": "Resource",
+            "Value": "/users",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiLatencyAlarmDFFFBED2": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect when the API Gateway requests in a stage have high latency.",
+        "AlarmName": "TestApi - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiproxyANY1786B242": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApiproxyC95856DD",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiproxyC95856DD": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "testApiAccessLogGroup1F4A8AE6": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "LogGroupName": "/apigateway/testapi/accesslogs",
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`default alarm actions are overridden when individual alarm actions are provided in configuration 1`] = `
+Object {
+  "Outputs": Object {
+    "RestApiEndpoint0551178A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "LambdaD247545B": Object {
+      "DependsOn": Array [
+        "LambdaServiceRoleA8ED4D3B",
+      ],
+      "Properties": Object {
+        "Code": Object {
+          "ZipFile": "exports.handler = async (event) => { console.log(event); }",
+        },
+        "Handler": "index.handler",
+        "Role": Object {
+          "Fn::GetAtt": Array [
+            "LambdaServiceRoleA8ED4D3B",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "LambdaRestApi4XXErrorAlarmPermissionC1439F61": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "LambdaD247545B",
+            "Arn",
+          ],
+        },
+        "Principal": "lambda.alarms.cloudwatch.amazonaws.com",
+        "SourceAccount": "123456789012",
+        "SourceArn": Object {
+          "Fn::GetAtt": Array [
+            "apiGatewayRestApiAlarmsRestApi4XXError8B075579",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "LambdaRestApi5XXErrorAlarmPermission96CA4D55": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "LambdaD247545B",
+            "Arn",
+          ],
+        },
+        "Principal": "lambda.alarms.cloudwatch.amazonaws.com",
+        "SourceAccount": "123456789012",
+        "SourceArn": Object {
+          "Fn::GetAtt": Array [
+            "apiGatewayRestApiAlarmsRestApi5XXError005F45E2",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "LambdaRestApiCountAlarmPermission5E8C395C": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "LambdaD247545B",
+            "Arn",
+          ],
+        },
+        "Principal": "lambda.alarms.cloudwatch.amazonaws.com",
+        "SourceAccount": "123456789012",
+        "SourceArn": Object {
+          "Fn::GetAtt": Array [
+            "apiGatewayRestApiAlarmsRestApiCountB292920F",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "LambdaRestApiLatencyAlarmPermission8EF227F1": Object {
+      "Properties": Object {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": Object {
+          "Fn::GetAtt": Array [
+            "LambdaD247545B",
+            "Arn",
+          ],
+        },
+        "Principal": "lambda.alarms.cloudwatch.amazonaws.com",
+        "SourceAccount": "123456789012",
+        "SourceArn": Object {
+          "Fn::GetAtt": Array [
+            "apiGatewayRestApiAlarmsRestApiLatencyCD758518",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "LambdaServiceRoleA8ED4D3B": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "RestApi0C43BF4B": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiANYA7C1DC94": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiAccount7C83CF5A": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiCloudWatchRoleE3ED6605": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e": Object {
+      "DependsOn": Array [
+        "RestApiproxyANY1786B242",
+        "RestApiproxyC95856DD",
+        "RestApiANYA7C1DC94",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageliveE585F0C9": Object {
+      "DependsOn": Array [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "testApiAccessLogGroup1F4A8AE6",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"method\\":\\"$context.httpMethod\\",\\"userContext\\":{\\"apiKeyId\\":\\"$context.identity.apiKeyId\\",\\"userAgent\\":\\"$context.identity.userAgent\\"},\\"requestPath\\":\\"$context.path\\",\\"requestTime\\":\\"$context.requestTime\\",\\"error\\":{\\"message\\":\\"$context.error.message\\",\\"responseType\\":\\"$context.error.responseType\\"},\\"waf\\":{\\"responseCode\\":\\"$context.wafResponseCode\\",\\"error\\":\\"$context.waf.error\\",\\"latency\\":\\"$context.waf.latency\\",\\"status\\":\\"$context.waf.status\\"},\\"integration\\":{\\"error\\":\\"$context.integrationErrorMessage\\",\\"latency\\":\\"$context.integrationLatency\\",\\"status\\":\\"$context.integrationStatus\\"},\\"authorizer\\":{\\"error\\":\\"$context.authorizer.error\\",\\"latency\\":\\"$context.authorizer.latency\\",\\"status\\":\\"$context.authorizer.status\\",\\"integration\\":{\\"latency\\":\\"$context.authorizer.integrationLatency\\",\\"status\\":\\"$context.authorizer.integrationStatus\\"}},\\"customDomainBasePath\\":\\"$context.customDomain.basePathMatched\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"status\\":\\"$context.status\\"}",
+        },
+        "DeploymentId": Object {
+          "Ref": "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApiproxyANY1786B242": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApiproxyC95856DD",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiproxyC95856DD": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "TopicBFC7AF6E": Object {
+      "Type": "AWS::SNS::Topic",
+    },
+    "apiGatewayRestApiAlarmsRestApi4XXError8B075579": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "AlarmDescription": "This alarm can detect high rates of client-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 4XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "InsufficientDataActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApi5XXError005F45E2": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "AlarmDescription": "This alarm can detect high rates of server-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 5XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "InsufficientDataActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApiCountB292920F": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "AlarmDescription": "This alarm can detect unexpectedly low traffic volume for the REST API stage.",
+        "AlarmName": "TestApi - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "InsufficientDataActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apiGatewayRestApiAlarmsRestApiLatencyCD758518": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "AlarmDescription": "This alarm can detect when the API Gateway requests in a stage have high latency.",
+        "AlarmName": "TestApi - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "InsufficientDataActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LambdaD247545B",
+              "Arn",
+            ],
+          },
+        ],
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "testApiAccessLogGroup1F4A8AE6": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "LogGroupName": "/apigateway/testapi/accesslogs",
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`optional alarm configurations can be overwritten 1`] = `
+Object {
+  "Outputs": Object {
+    "RestApi1Endpoint9538EE78": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi1480AC499",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApi1DeploymentStagelive146493FD",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "RestApi1480AC499": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi1",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApi1ANY857DBD69": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi1480AC499",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi1480AC499",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApi1Account2FA629B2": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi1480AC499",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApi1CloudWatchRole9ED447DC",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApi1ApiGatewayRestApiRecommendedAlarmsFromAspectRestApi14XXErrorDEAA528F": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "Custom alarm description",
+        "AlarmName": "Custom4XXErrorAlarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 25,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi1",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApi1DeploymentStagelive146493FD",
+            },
+          },
+        ],
+        "EvaluationPeriods": 25,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 300,
+        "Statistic": "Average",
+        "Threshold": 10,
+        "TreatMissingData": "ignore",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi1ApiGatewayRestApiRecommendedAlarmsFromAspectRestApi15XXErrorA6B38A50": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "Custom alarm description",
+        "AlarmName": "Custom5XXErrorAlarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 25,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi1",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApi1DeploymentStagelive146493FD",
+            },
+          },
+        ],
+        "EvaluationPeriods": 25,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 300,
+        "Statistic": "Average",
+        "Threshold": 10,
+        "TreatMissingData": "ignore",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi1ApiGatewayRestApiRecommendedAlarmsFromAspectRestApi1Count9D71474E": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "Custom alarm description",
+        "AlarmName": "CustomCountAlarm",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 25,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi1",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApi1DeploymentStagelive146493FD",
+            },
+          },
+        ],
+        "EvaluationPeriods": 25,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 300,
+        "Statistic": "SampleCount",
+        "Threshold": 10,
+        "TreatMissingData": "ignore",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi1ApiGatewayRestApiRecommendedAlarmsFromAspectRestApi1DetailedCount02D1747A4": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "Custom alarm description",
+        "AlarmName": "CustomDetailedGetUsersCountAlarm",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 25,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi1",
+          },
+          Object {
+            "Name": "Method",
+            "Value": "GET",
+          },
+          Object {
+            "Name": "Resource",
+            "Value": "/users",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApi1DeploymentStagelive146493FD",
+            },
+          },
+        ],
+        "EvaluationPeriods": 25,
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 300,
+        "Statistic": "SampleCount",
+        "Threshold": 1000,
+        "TreatMissingData": "ignore",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi1ApiGatewayRestApiRecommendedAlarmsFromAspectRestApi1DetailedLatency09F19D01C": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "Custom alarm description",
+        "AlarmName": "CustomDetailedGetUsersLatencyAlarm",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 25,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi1",
+          },
+          Object {
+            "Name": "Method",
+            "Value": "GET",
+          },
+          Object {
+            "Name": "Resource",
+            "Value": "/users",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApi1DeploymentStagelive146493FD",
+            },
+          },
+        ],
+        "EvaluationPeriods": 25,
+        "ExtendedStatistic": "p90",
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 300,
+        "Threshold": 10,
+        "TreatMissingData": "ignore",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi1ApiGatewayRestApiRecommendedAlarmsFromAspectRestApi1Latency38B1EC96": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "Custom alarm description",
+        "AlarmName": "CustomLatencyAlarm",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 25,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi1",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApi1DeploymentStagelive146493FD",
+            },
+          },
+        ],
+        "EvaluationPeriods": 25,
+        "ExtendedStatistic": "p90",
+        "InsufficientDataActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "Period": 300,
+        "Threshold": 10,
+        "TreatMissingData": "ignore",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi1CloudWatchRole9ED447DC": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApi1Deployment82EFFB3715975013ff8a6c177d3b14661b4133d7": Object {
+      "DependsOn": Array [
+        "RestApi1proxyANY1C0834C0",
+        "RestApi1proxy48E25E9D",
+        "RestApi1ANY857DBD69",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi1480AC499",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApi1DeploymentStagelive146493FD": Object {
+      "DependsOn": Array [
+        "RestApi1Account2FA629B2",
+      ],
+      "Properties": Object {
+        "DeploymentId": Object {
+          "Ref": "RestApi1Deployment82EFFB3715975013ff8a6c177d3b14661b4133d7",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi1480AC499",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApi1proxy48E25E9D": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi1480AC499",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi1480AC499",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApi1proxyANY1C0834C0": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApi1proxy48E25E9D",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi1480AC499",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "TopicBFC7AF6E": Object {
+      "Type": "AWS::SNS::Topic",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`stack should contain service recommended alarms if recommended alarms aspect is applied with no exclusions 1`] = `
+Object {
+  "Outputs": Object {
+    "RestApiEndpoint0551178A": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi0C43BF4B",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "RestApi0C43BF4B": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApiANYA7C1DC94": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiAccount7C83CF5A": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi0C43BF4B",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApiCloudWatchRoleE3ED6605",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApi4XXError6FA6D9EE": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of client-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 4XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApi5XXErrorB8ED282A": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of server-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi - 5XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApiCountF4908B9F": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect unexpectedly low traffic volume for the REST API stage.",
+        "AlarmName": "TestApi - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiApiGatewayRestApiRecommendedAlarmsFromAspectRestApiLatencyFB41F7A4": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect when the API Gateway requests in a stage have high latency.",
+        "AlarmName": "TestApi - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApiDeploymentStageliveE585F0C9",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApiCloudWatchRoleE3ED6605": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e": Object {
+      "DependsOn": Array [
+        "RestApiproxyANY1786B242",
+        "RestApiproxyC95856DD",
+        "RestApiANYA7C1DC94",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApiDeploymentStageliveE585F0C9": Object {
+      "DependsOn": Array [
+        "RestApiAccount7C83CF5A",
+      ],
+      "Properties": Object {
+        "AccessLogSetting": Object {
+          "DestinationArn": Object {
+            "Fn::GetAtt": Array [
+              "testApiAccessLogGroup1F4A8AE6",
+              "Arn",
+            ],
+          },
+          "Format": "{\\"requestId\\":\\"$context.requestId\\",\\"sourceIp\\":\\"$context.identity.sourceIp\\",\\"method\\":\\"$context.httpMethod\\",\\"userContext\\":{\\"apiKeyId\\":\\"$context.identity.apiKeyId\\",\\"userAgent\\":\\"$context.identity.userAgent\\"},\\"requestPath\\":\\"$context.path\\",\\"requestTime\\":\\"$context.requestTime\\",\\"error\\":{\\"message\\":\\"$context.error.message\\",\\"responseType\\":\\"$context.error.responseType\\"},\\"waf\\":{\\"responseCode\\":\\"$context.wafResponseCode\\",\\"error\\":\\"$context.waf.error\\",\\"latency\\":\\"$context.waf.latency\\",\\"status\\":\\"$context.waf.status\\"},\\"integration\\":{\\"error\\":\\"$context.integrationErrorMessage\\",\\"latency\\":\\"$context.integrationLatency\\",\\"status\\":\\"$context.integrationStatus\\"},\\"authorizer\\":{\\"error\\":\\"$context.authorizer.error\\",\\"latency\\":\\"$context.authorizer.latency\\",\\"status\\":\\"$context.authorizer.status\\",\\"integration\\":{\\"latency\\":\\"$context.authorizer.integrationLatency\\",\\"status\\":\\"$context.authorizer.integrationStatus\\"}},\\"customDomainBasePath\\":\\"$context.customDomain.basePathMatched\\",\\"responseLength\\":\\"$context.responseLength\\",\\"responseLatency\\":\\"$context.responseLatency\\",\\"status\\":\\"$context.status\\"}",
+        },
+        "DeploymentId": Object {
+          "Ref": "RestApiDeployment180EC50302b1c063942af59f4edf9229b42bb78e",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApiproxyANY1786B242": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApiproxyC95856DD",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApiproxyC95856DD": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi0C43BF4B",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi0C43BF4B",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "testApiAccessLogGroup1F4A8AE6": Object {
+      "DeletionPolicy": "Delete",
+      "Properties": Object {
+        "LogGroupName": "/apigateway/testapi/accesslogs",
+        "RetentionInDays": 731,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`when a resource is excluded from the aspect config it should not have alarms 1`] = `
+Object {
+  "Outputs": Object {
+    "RestApi1Endpoint9538EE78": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi1480AC499",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApi1DeploymentStagelive146493FD",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+    "RestApi2Endpoint575A9CAF": Object {
+      "Value": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "https://",
+            Object {
+              "Ref": "RestApi2EB2B1A40",
+            },
+            ".execute-api.us-east-1.",
+            Object {
+              "Ref": "AWS::URLSuffix",
+            },
+            "/",
+            Object {
+              "Ref": "RestApi2DeploymentStagelive144C5CE7",
+            },
+            "/",
+          ],
+        ],
+      },
+    },
+  },
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "RestApi1480AC499": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi1",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApi1ANY857DBD69": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi1480AC499",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi1480AC499",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApi1Account2FA629B2": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi1480AC499",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApi1CloudWatchRole9ED447DC",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApi1CloudWatchRole9ED447DC": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApi1Deployment82EFFB3715975013ff8a6c177d3b14661b4133d7": Object {
+      "DependsOn": Array [
+        "RestApi1proxyANY1C0834C0",
+        "RestApi1proxy48E25E9D",
+        "RestApi1ANY857DBD69",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi1480AC499",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApi1DeploymentStagelive146493FD": Object {
+      "DependsOn": Array [
+        "RestApi1Account2FA629B2",
+      ],
+      "Properties": Object {
+        "DeploymentId": Object {
+          "Ref": "RestApi1Deployment82EFFB3715975013ff8a6c177d3b14661b4133d7",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi1480AC499",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApi1proxy48E25E9D": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi1480AC499",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi1480AC499",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApi1proxyANY1C0834C0": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApi1proxy48E25E9D",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi1480AC499",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApi2ANY327F0C93": Object {
+      "Properties": Object {
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "ResourceId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi2EB2B1A40",
+            "RootResourceId",
+          ],
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi2EB2B1A40",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+    "RestApi2Account0F84FE1F": Object {
+      "DeletionPolicy": "Retain",
+      "DependsOn": Array [
+        "RestApi2EB2B1A40",
+      ],
+      "Properties": Object {
+        "CloudWatchRoleArn": Object {
+          "Fn::GetAtt": Array [
+            "RestApi2CloudWatchRoleCE2D27D6",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApi2ApiGatewayRestApiRecommendedAlarmsFromAspectRestApi24XXError54D124D6": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of client-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi2 - 4XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi2",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApi2DeploymentStagelive144C5CE7",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "4XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi2ApiGatewayRestApiRecommendedAlarmsFromAspectRestApi25XXError879C2770": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect high rates of server-side errors for the API Gateway requests.",
+        "AlarmName": "TestApi2 - 5XXError",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi2",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApi2DeploymentStagelive144C5CE7",
+            },
+          },
+        ],
+        "EvaluationPeriods": 3,
+        "MetricName": "5XXError",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 0.05,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi2ApiGatewayRestApiRecommendedAlarmsFromAspectRestApi2Count186EE132": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect unexpectedly low traffic volume for the REST API stage.",
+        "AlarmName": "TestApi2 - Count",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 10,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi2",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApi2DeploymentStagelive144C5CE7",
+            },
+          },
+        ],
+        "EvaluationPeriods": 10,
+        "MetricName": "Count",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Statistic": "SampleCount",
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi2ApiGatewayRestApiRecommendedAlarmsFromAspectRestApi2Latency3AA43266": Object {
+      "Properties": Object {
+        "AlarmDescription": "This alarm can detect when the API Gateway requests in a stage have high latency.",
+        "AlarmName": "TestApi2 - Latency",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "ApiName",
+            "Value": "TestApi2",
+          },
+          Object {
+            "Name": "Stage",
+            "Value": Object {
+              "Ref": "RestApi2DeploymentStagelive144C5CE7",
+            },
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "ExtendedStatistic": "p90",
+        "MetricName": "Latency",
+        "Namespace": "AWS/ApiGateway",
+        "Period": 60,
+        "Threshold": 2500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestApi2CloudWatchRoleCE2D27D6": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "apigateway.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+              ],
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "RestApi2Deployment8AC5F7BB497d3c03a5112cd8ce644daf98590b89": Object {
+      "DependsOn": Array [
+        "RestApi2proxyANYBF55D3BC",
+        "RestApi2proxy1E46C68B",
+        "RestApi2ANY327F0C93",
+      ],
+      "Properties": Object {
+        "Description": "Automatically created by the RestApi construct",
+        "RestApiId": Object {
+          "Ref": "RestApi2EB2B1A40",
+        },
+      },
+      "Type": "AWS::ApiGateway::Deployment",
+    },
+    "RestApi2DeploymentStagelive144C5CE7": Object {
+      "DependsOn": Array [
+        "RestApi2Account0F84FE1F",
+      ],
+      "Properties": Object {
+        "DeploymentId": Object {
+          "Ref": "RestApi2Deployment8AC5F7BB497d3c03a5112cd8ce644daf98590b89",
+        },
+        "MethodSettings": Array [
+          Object {
+            "DataTraceEnabled": false,
+            "HttpMethod": "*",
+            "LoggingLevel": "INFO",
+            "ResourcePath": "/*",
+          },
+        ],
+        "RestApiId": Object {
+          "Ref": "RestApi2EB2B1A40",
+        },
+        "StageName": "live",
+      },
+      "Type": "AWS::ApiGateway::Stage",
+    },
+    "RestApi2EB2B1A40": Object {
+      "Properties": Object {
+        "EndpointConfiguration": Object {
+          "Types": Array [
+            "REGIONAL",
+          ],
+        },
+        "Name": "TestApi2",
+      },
+      "Type": "AWS::ApiGateway::RestApi",
+    },
+    "RestApi2proxy1E46C68B": Object {
+      "Properties": Object {
+        "ParentId": Object {
+          "Fn::GetAtt": Array [
+            "RestApi2EB2B1A40",
+            "RootResourceId",
+          ],
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": Object {
+          "Ref": "RestApi2EB2B1A40",
+        },
+      },
+      "Type": "AWS::ApiGateway::Resource",
+    },
+    "RestApi2proxyANYBF55D3BC": Object {
+      "Properties": Object {
+        "ApiKeyRequired": false,
+        "AuthorizationType": "NONE",
+        "HttpMethod": "ANY",
+        "Integration": Object {
+          "Type": "MOCK",
+        },
+        "RequestParameters": Object {
+          "method.request.path.proxy": true,
+        },
+        "ResourceId": Object {
+          "Ref": "RestApi2proxy1E46C68B",
+        },
+        "RestApiId": Object {
+          "Ref": "RestApi2EB2B1A40",
+        },
+      },
+      "Type": "AWS::ApiGateway::Method",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/test/apigateway.test.ts
+++ b/test/apigateway.test.ts
@@ -1,0 +1,665 @@
+import {
+  aws_apigateway as apigateway,
+  aws_cloudwatch as cloudwatch,
+  aws_cloudwatch_actions as cloudwatch_actions,
+  aws_lambda as lambda,
+  aws_logs as logs,
+  aws_sns as sns,
+  Aspects,
+  App,
+  Duration,
+  RemovalPolicy,
+  Stack,
+  StackProps,
+} from 'aws-cdk-lib';
+import {
+  Template,
+  Match,
+} from 'aws-cdk-lib/assertions';
+import * as apiGatewayAlarms from '../src/apigateway';
+
+class ApiGatewayRestApiStack extends Stack {
+
+  public readonly api: apiGatewayAlarms.RestApi;
+
+  constructor(scope: App, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const apiAccessLogGroup = new logs.LogGroup(this, 'testApiAccessLogGroup', {
+      retention: logs.RetentionDays.TWO_YEARS,
+      logGroupName: '/apigateway/testapi/accesslogs',
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
+    this.api = new apiGatewayAlarms.RestApi(this, 'RestApi', {
+      restApiName: 'TestApi',
+      endpointTypes: [apigateway.EndpointType.REGIONAL],
+      deployOptions: {
+        stageName: 'live',
+        loggingLevel: apigateway.MethodLoggingLevel.INFO,
+        dataTraceEnabled: false,
+        accessLogDestination: new apigateway.LogGroupLogDestination(apiAccessLogGroup),
+        accessLogFormat: apigateway.AccessLogFormat.custom(JSON.stringify({
+          requestId: apigateway.AccessLogField.contextRequestId(),
+          sourceIp: apigateway.AccessLogField.contextIdentitySourceIp(),
+          method: apigateway.AccessLogField.contextHttpMethod(),
+          userContext: {
+            apiKeyId: apigateway.AccessLogField.contextIdentityApiKeyId(),
+            userAgent: apigateway.AccessLogField.contextIdentityUserAgent(),
+          },
+          requestPath: apigateway.AccessLogField.contextPath(),
+          requestTime: apigateway.AccessLogField.contextRequestTime(),
+          error: {
+            message: apigateway.AccessLogField.contextErrorMessage(),
+            responseType: apigateway.AccessLogField.contextErrorResponseType(),
+          },
+          waf: {
+            responseCode: apigateway.AccessLogField.contextWafResponseCode(),
+            error: apigateway.AccessLogField.contextWafError(),
+            latency: apigateway.AccessLogField.contextWafLatency(),
+            status: apigateway.AccessLogField.contextWafStatus(),
+          },
+          integration: {
+            error: apigateway.AccessLogField.contextIntegrationErrorMessage(),
+            latency: apigateway.AccessLogField.contextIntegrationLatency(),
+            status: apigateway.AccessLogField.contextIntegrationStatus(),
+          },
+          authorizer: {
+            error: apigateway.AccessLogField.contextAuthorizerError(),
+            latency: apigateway.AccessLogField.contextAuthorizerLatency(),
+            status: apigateway.AccessLogField.contextAuthorizerStatus(),
+            integration: {
+              latency: apigateway.AccessLogField.contextAuthorizerIntegrationLatency(),
+              status: apigateway.AccessLogField.contextAuthorizerIntegrationStatus(),
+            },
+          },
+          customDomainBasePath: apigateway.AccessLogField.contextCustomDomainBasePathMatched(),
+          responseLength: apigateway.AccessLogField.contextResponseLength(),
+          responseLatency: apigateway.AccessLogField.contextResponseLatency(),
+          status: apigateway.AccessLogField.contextStatus(),
+        })),
+      },
+    });
+
+    this.api.root.addProxy({
+      anyMethod: true,
+      defaultMethodOptions: {
+        apiKeyRequired: false,
+        requestParameters: {
+          'method.request.path.proxy': true,
+        },
+      },
+    });
+  }
+}
+
+test('RestApiSnapshot', () => {
+  const app = new App();
+  const appAspects = Aspects.of(app);
+
+  appAspects.add(
+    new apiGatewayAlarms.ApiGatewayRecommendedAlarmsAspect({
+      configCountAlarm: {
+        threshold: 10,
+      },
+    }),
+  );
+
+  const stack = new ApiGatewayRestApiStack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+
+  const template = Template.fromStack(stack);
+  expect(template).toMatchSnapshot();
+});
+
+test('RestApiSnapshotWithDetailedList', () => {
+  const app = new App();
+  const appAspects = Aspects.of(app);
+
+  appAspects.add(
+    new apiGatewayAlarms.ApiGatewayRecommendedAlarmsAspect({
+      configCountAlarm: {
+        threshold: 10,
+      },
+      configDetailedCountAlarmList: [
+        {
+          alias: 'getUsers',
+          resource: '/users',
+          method: 'GET',
+          threshold: 1000,
+        },
+      ],
+      configDetailedLatencyAlarmList: [
+        {
+          alias: 'getUsers',
+          resource: '/users',
+          method: 'GET',
+        },
+      ],
+    }),
+  );
+
+  const stack = new ApiGatewayRestApiStack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+
+  const template = Template.fromStack(stack);
+  expect(template).toMatchSnapshot();
+});
+
+test('RestApiSnapshotWithExclusion', () => {
+  const app = new App();
+  const appAspects = Aspects.of(app);
+
+  appAspects.add(
+    new apiGatewayAlarms.ApiGatewayRecommendedAlarmsAspect({
+      excludeAlarms: [apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics.ERROR_4XX],
+      configCountAlarm: {
+        threshold: 10,
+      },
+    }),
+  );
+
+  const stack = new ApiGatewayRestApiStack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+
+  const template = Template.fromStack(stack);
+  expect(template).toMatchSnapshot();
+});
+
+test('SnapshotForRestApiConstruct', () => {
+  const app = new App();
+  const stack = new ApiGatewayRestApiStack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+
+  stack.api.applyRecommendedAlarms({
+    configCountAlarm: {
+      threshold: 10,
+    },
+  });
+
+  const template = Template.fromStack(stack);
+  expect(template).toMatchSnapshot();
+});
+
+test('RestApiSnapshotDefaultActionsInUse', () => {
+  const app = new App();
+  const stack = new ApiGatewayRestApiStack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+
+  const alarmTopic = new sns.Topic(stack, 'Topic');
+
+  new apiGatewayAlarms.ApiGatewayRestApiRecommendedAlarms(stack, 'apiGatewayRestApiAlarms', {
+    api: stack.api,
+    defaultAlarmAction: new cloudwatch_actions.SnsAction(alarmTopic),
+    defaultOkAction: new cloudwatch_actions.SnsAction(alarmTopic),
+    defaultInsufficientDataAction: new cloudwatch_actions.SnsAction(alarmTopic),
+    configCountAlarm: {
+      threshold: 10,
+    },
+  });
+
+  const template = Template.fromStack(stack);
+  expect(template).toMatchSnapshot();
+});
+
+test('RestApiSnapshotDefaultActionsInUseWithDetails', () => {
+  const app = new App();
+  const stack = new ApiGatewayRestApiStack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+
+  const alarmTopic = new sns.Topic(stack, 'Topic');
+
+  new apiGatewayAlarms.ApiGatewayRestApiRecommendedAlarms(stack, 'apiGatewayRestApiAlarms', {
+    api: stack.api,
+    defaultAlarmAction: new cloudwatch_actions.SnsAction(alarmTopic),
+    defaultOkAction: new cloudwatch_actions.SnsAction(alarmTopic),
+    defaultInsufficientDataAction: new cloudwatch_actions.SnsAction(alarmTopic),
+    configCountAlarm: {
+      threshold: 10,
+    },
+    configDetailedCountAlarmList: [
+      {
+        alias: 'getUsers',
+        resource: '/users',
+        method: 'GET',
+        threshold: 1000,
+      },
+      {
+        alias: 'createUser',
+        resource: '/users',
+        method: 'POST',
+        threshold: 1000,
+      },
+    ],
+    configDetailedLatencyAlarmList: [
+      {
+        alias: 'getUsers',
+        resource: '/users',
+        method: 'GET',
+      },
+      {
+        alias: 'createUser',
+        resource: '/users',
+        method: 'POST',
+      },
+    ],
+  });
+
+  const template = Template.fromStack(stack);
+  expect(template).toMatchSnapshot();
+});
+
+test('stack should contain service recommended alarms if recommended alarms aspect is applied with no exclusions', () => {
+  const app = new App();
+  const appAspects = Aspects.of(app);
+
+  appAspects.add(
+    new apiGatewayAlarms.ApiGatewayRecommendedAlarmsAspect({
+      configCountAlarm: {
+        threshold: 10,
+      },
+    }),
+  );
+
+  const stack = new ApiGatewayRestApiStack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+
+  const template = Template.fromStack(stack);
+  expect(template).toMatchSnapshot();
+
+  const numOfMetrics = Object.keys(apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics).length;
+
+  template.resourceCountIs('AWS::CloudWatch::Alarm', numOfMetrics);
+
+  const resources = template.findResources('AWS::CloudWatch::Alarm');
+
+  Object.keys(apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics).forEach(metricKey => {
+    const alarms = Object.keys(resources).filter(resourceName => {
+      const resource =
+        resources[resourceName];
+      const resourceProperties = resource.Properties;
+      const metricName = apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics[
+        metricKey as keyof typeof apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics
+      ];
+
+      return resourceProperties.MetricName === metricName;
+    });
+
+    expect(alarms.length).toEqual(1);
+  });
+});
+
+test('alarms can be applied individually to services using extended construct', () => {
+  const app = new App();
+  const stack = new ApiGatewayRestApiStack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+  const alarmDetailCountConfig = [
+    {
+      alias: 'getUsers',
+      resource: '/users',
+      method: 'GET',
+      threshold: 1000,
+    },
+  ];
+  const alarmDetailLatencyConfig = [
+    {
+      alias: 'getUsers',
+      resource: '/users',
+      method: 'GET',
+    },
+  ];
+
+  stack.api.alarm4XXError();
+  stack.api.alarm5XXError();
+  stack.api.alarmCount({ threshold: 10 });
+  stack.api.alarmLatency();
+  stack.api.alarmDetailedCount(alarmDetailCountConfig);
+  stack.api.alarmDetailedLatency(alarmDetailLatencyConfig);
+
+  const template = Template.fromStack(stack);
+  expect(template).toMatchSnapshot();
+
+  const numOfMetrics = Object.keys(apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics).length;
+
+  template.resourceCountIs('AWS::CloudWatch::Alarm', numOfMetrics + alarmDetailCountConfig.length + alarmDetailLatencyConfig.length);
+
+  const resources = template.findResources('AWS::CloudWatch::Alarm');
+
+  Object.values(apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics).forEach(metricName => {
+    const alarms = Object.keys(resources).filter(resourceName => {
+      const resource = resources[resourceName];
+      const resourceProperties = resource.Properties;
+
+      return resourceProperties.MetricName === metricName;
+    });
+
+    if (metricName === apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics.COUNT) {
+      expect(alarms.length).toBe(1 + alarmDetailCountConfig.length);
+    } else if (metricName === apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics.LATENCY) {
+      expect(alarms.length).toBe(1 + alarmDetailLatencyConfig.length);
+    } else {
+      expect(alarms.length).toBe(1);
+    }
+  });
+});
+
+test('when a resource is excluded from the aspect config it should not have alarms', () => {
+  const app = new App();
+  const stack = new Stack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+
+  const appAspects = Aspects.of(app);
+
+  appAspects.add(
+    new apiGatewayAlarms.ApiGatewayRecommendedAlarmsAspect({
+      excludeResources: ['RestApi1'],
+      configCountAlarm: {
+        threshold: 10,
+      },
+    }),
+  );
+
+  const api1 = new apiGatewayAlarms.RestApi(stack, 'RestApi1', {
+    restApiName: 'TestApi1',
+    endpointTypes: [apigateway.EndpointType.REGIONAL],
+    deployOptions: {
+      stageName: 'live',
+      loggingLevel: apigateway.MethodLoggingLevel.INFO,
+      dataTraceEnabled: false,
+    },
+  });
+
+  api1.root.addProxy({
+    anyMethod: true,
+    defaultMethodOptions: {
+      apiKeyRequired: false,
+      requestParameters: {
+        'method.request.path.proxy': true,
+      },
+    },
+  });
+
+  const api2 = new apiGatewayAlarms.RestApi(stack, 'RestApi2', {
+    restApiName: 'TestApi2',
+    endpointTypes: [apigateway.EndpointType.REGIONAL],
+    deployOptions: {
+      stageName: 'live',
+      loggingLevel: apigateway.MethodLoggingLevel.INFO,
+      dataTraceEnabled: false,
+    },
+  });
+
+  api2.root.addProxy({
+    anyMethod: true,
+    defaultMethodOptions: {
+      apiKeyRequired: false,
+      requestParameters: {
+        'method.request.path.proxy': true,
+      },
+    },
+  });
+
+  const template = Template.fromStack(stack);
+  expect(template).toMatchSnapshot();
+
+  const numOfMetrics = Object.keys(apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics).length;
+
+  const resources = template.findResources('AWS::CloudWatch::Alarm');
+  expect(Object.keys(resources).length).toEqual(numOfMetrics);
+
+  ['RestApi1', 'RestApi2'].forEach(instanceName => {
+    Object.keys(apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics).forEach(metricKey => {
+      const alarms = Object.keys(resources).filter(resourceName => {
+        const resource = resources[resourceName];
+        const resourceProperties = resource.Properties;
+        const metricName = apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics[
+          metricKey as keyof typeof apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics
+        ];
+
+        return resourceName.startsWith(instanceName) && resourceProperties.MetricName === metricName;
+      });
+      if (instanceName === 'RestApi1') {
+        expect(alarms.length).toEqual(0);
+      } else {
+        expect(alarms.length).toEqual(1);
+      }
+    });
+  });
+});
+
+test('default alarm actions are overridden when individual alarm actions are provided in configuration', () => {
+  const app = new App({
+    context: {
+      '@aws-cdk/aws-cloudwatch-actions:changeLambdaPermissionLogicalIdForLambdaAction': true,
+    },
+  });
+  const stack = new ApiGatewayRestApiStack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+
+  const topic = new sns.Topic(stack, 'Topic');
+
+  const alarmLambda = new lambda.Function(stack, 'Lambda', {
+    runtime: lambda.Runtime.NODEJS_20_X,
+    handler: 'index.handler',
+    code: lambda.Code.fromInline('exports.handler = async (event) => { console.log(event); }'),
+  });
+
+  new apiGatewayAlarms.ApiGatewayRestApiRecommendedAlarms(stack, 'apiGatewayRestApiAlarms', {
+    api: stack.api,
+    defaultAlarmAction: new cloudwatch_actions.SnsAction(topic),
+    defaultOkAction: new cloudwatch_actions.SnsAction(topic),
+    defaultInsufficientDataAction: new cloudwatch_actions.SnsAction(topic),
+    config4XXErrorAlarm: {
+      alarmAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+      okAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+      insufficientDataAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+    },
+    config5XXErrorAlarm: {
+      alarmAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+      okAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+      insufficientDataAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+    },
+    configCountAlarm: {
+      alarmAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+      okAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+      insufficientDataAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+      threshold: 10,
+    },
+    configLatencyAlarm: {
+      alarmAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+      okAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+      insufficientDataAction: new cloudwatch_actions.LambdaAction(alarmLambda),
+    },
+  });
+
+  const template = Template.fromStack(stack);
+  expect(template).toMatchSnapshot();
+
+  Object.values(apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics).forEach(metricName => {
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', Match.objectLike({
+      MetricName: metricName,
+      AlarmActions: [Match.objectLike({ 'Fn::GetAtt': [Match.stringLikeRegexp('^Lambda.*'), 'Arn'] })],
+      OKActions: [Match.objectLike({ 'Fn::GetAtt': [Match.stringLikeRegexp('^Lambda.*'), 'Arn'] })],
+      InsufficientDataActions: [Match.objectLike({ 'Fn::GetAtt': [Match.stringLikeRegexp('^Lambda.*'), 'Arn'] })],
+    }));
+  });
+});
+
+test('optional alarm configurations can be overwritten', () => {
+  const app = new App();
+  const appAspects = Aspects.of(app);
+  const stack = new Stack(app, 'TestStack', {
+    env: {
+      account: '123456789012', // not a real account
+      region: 'us-east-1',
+    },
+  });
+
+  const topic = new sns.Topic(stack, 'Topic');
+  const topicAction = new cloudwatch_actions.SnsAction(topic);
+
+  appAspects.add(
+    new apiGatewayAlarms.ApiGatewayRecommendedAlarmsAspect({
+      config4XXErrorAlarm: {
+        alarmName: 'Custom4XXErrorAlarm',
+        threshold: 10,
+        period: Duration.minutes(5),
+        evaluationPeriods: 25,
+        datapointsToAlarm: 25,
+        alarmDescription: 'Custom alarm description',
+        treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+        alarmAction: topicAction,
+        okAction: topicAction,
+        insufficientDataAction: topicAction,
+      },
+      config5XXErrorAlarm: {
+        alarmName: 'Custom5XXErrorAlarm',
+        threshold: 10,
+        period: Duration.minutes(5),
+        evaluationPeriods: 25,
+        datapointsToAlarm: 25,
+        alarmDescription: 'Custom alarm description',
+        treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+        alarmAction: topicAction,
+        okAction: topicAction,
+        insufficientDataAction: topicAction,
+      },
+      configCountAlarm: {
+        alarmName: 'CustomCountAlarm',
+        threshold: 10,
+        period: Duration.minutes(5),
+        evaluationPeriods: 25,
+        datapointsToAlarm: 25,
+        alarmDescription: 'Custom alarm description',
+        treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+        alarmAction: topicAction,
+        okAction: topicAction,
+        insufficientDataAction: topicAction,
+      },
+      configLatencyAlarm: {
+        alarmName: 'CustomLatencyAlarm',
+        threshold: 10,
+        period: Duration.minutes(5),
+        evaluationPeriods: 25,
+        datapointsToAlarm: 25,
+        alarmDescription: 'Custom alarm description',
+        treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+        alarmAction: topicAction,
+        okAction: topicAction,
+        insufficientDataAction: topicAction,
+      },
+      configDetailedCountAlarmList: [
+        {
+          alias: 'getUsers',
+          resource: '/users',
+          method: 'GET',
+          alarmName: 'CustomDetailedGetUsersCountAlarm',
+          threshold: 1000,
+          period: Duration.minutes(5),
+          evaluationPeriods: 25,
+          datapointsToAlarm: 25,
+          alarmDescription: 'Custom alarm description',
+          treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+          alarmAction: topicAction,
+          okAction: topicAction,
+          insufficientDataAction: topicAction,
+        },
+      ],
+      configDetailedLatencyAlarmList: [
+        {
+          alias: 'getUsers',
+          resource: '/users',
+          method: 'GET',
+          alarmName: 'CustomDetailedGetUsersLatencyAlarm',
+          threshold: 10,
+          period: Duration.minutes(5),
+          evaluationPeriods: 25,
+          datapointsToAlarm: 25,
+          alarmDescription: 'Custom alarm description',
+          treatMissingData: cloudwatch.TreatMissingData.IGNORE,
+          alarmAction: topicAction,
+          okAction: topicAction,
+          insufficientDataAction: topicAction,
+        },
+      ],
+    }),
+  );
+
+  const api = new apiGatewayAlarms.RestApi(stack, 'RestApi1', {
+    restApiName: 'TestApi1',
+    endpointTypes: [apigateway.EndpointType.REGIONAL],
+    deployOptions: {
+      stageName: 'live',
+      loggingLevel: apigateway.MethodLoggingLevel.INFO,
+      dataTraceEnabled: false,
+    },
+  });
+
+  api.root.addProxy({
+    anyMethod: true,
+    defaultMethodOptions: {
+      apiKeyRequired: false,
+      requestParameters: {
+        'method.request.path.proxy': true,
+      },
+    },
+  });
+
+  const template = Template.fromStack(stack);
+  expect(template).toMatchSnapshot();
+
+  Object.values(apiGatewayAlarms.ApiGatewayRecommendedAlarmsMetrics).forEach(metricName => {
+    template.hasResourceProperties('AWS::CloudWatch::Alarm', Match.objectLike({
+      MetricName: metricName,
+      AlarmName: Match.stringLikeRegexp('^Custom.*'),
+      Period: 300,
+      EvaluationPeriods: 25,
+      DatapointsToAlarm: 25,
+      AlarmDescription: 'Custom alarm description',
+      TreatMissingData: 'ignore',
+      AlarmActions: [Match.objectLike({ Ref: Match.stringLikeRegexp('^Topic.*') })],
+      OKActions: [Match.objectLike({ Ref: Match.stringLikeRegexp('^Topic.*') })],
+      InsufficientDataActions: [Match.objectLike({ Ref: Match.stringLikeRegexp('^Topic.*') })],
+    }));
+  });
+});


### PR DESCRIPTION
This change implements the following alarms for `ApiGateway` service, specifically for the `RestApi` construct.  By default these 4 alarms use the `ApiName` and `Stage` dimensions.

- 4XXError (client-errors)
- 5XXError (server-errors)
- Count
- Latency
- Unit tests (100% coverage)

In order to create the Count and Latency alarms for Resource and Methods, the `configDetailedCountAlarmList` or `configDetailedLatencyAlarmList` must be specified.